### PR TITLE
23.2 RHEL/Rocky 8 node version update

### DIFF
--- a/roles/platform/vars/2023.2-redhat-8.yml
+++ b/roles/platform/vars/2023.2-redhat-8.yml
@@ -7,7 +7,7 @@ platform_packages:
   - openldap-clients
   - openssl
 
-iap_nodejs_package: "@nodejs:18"
+iap_nodejs_package: "@nodejs:20"
 
 python_version: 3.9
 python_executable: "/usr/bin/python{{ python_version }}"

--- a/roles/platform/vars/2023.2-rocky-8.yml
+++ b/roles/platform/vars/2023.2-rocky-8.yml
@@ -7,7 +7,7 @@ platform_packages:
   - openldap-clients
   - openssl
 
-iap_nodejs_package: "@nodejs:18"
+iap_nodejs_package: "@nodejs:20"
 
 python_version: 3.9
 python_executable: "/usr/bin/python{{ python_version }}"


### PR DESCRIPTION
23.2 RHEL and Rocky 8 now install node 20 instead of 18