### PR TITLE
Allow core to cleanup on systemctl stop

### DIFF
--- a/roles/platform/templates/automation-platform.service.j2
+++ b/roles/platform/templates/automation-platform.service.j2
@@ -10,6 +10,7 @@ WorkingDirectory={{ iap_install_dir }}/current
 ExecStart=/usr/bin/node --max-old-space-size=8192 server.js
 Restart=on-failure
 ExecReload=/bin/kill -USR2 $MAINPID
+KillMode=mixed
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The automation-platform logic assumes that stopping IAP entails stopping the `core` process, which handles shutting down all the services. By default systemd on stop, eg `systemctl stop` or `systemctl restart`, sends out a SIGTERM to both `core` and child processes. This occasionally causes a race condition where child processes kill themselves as core tries to kill them, resulting in poor shutdowns that sometimes
- Don't clean up bullmq connections
- Don't properly flush health statuses
- Ultimately fail to allow services to startup

Changing the KillMode to mixed sends the main SIGTERM just to `core`, and only when that fails it SIGKILLS the children and core. This is more in line with our assumptions of shutdowns and significantly reduces the race conditions above.