### PR TITLE
Create mongo-key for replication

### DIFF
--- a/roles/mongodb_auth/tasks/main.yml
+++ b/roles/mongodb_auth/tasks/main.yml
@@ -19,12 +19,12 @@
   when: mongodb_replication | bool
 
 - name: Check if key exists on the first node
+  ansible.builtin.stat:
+    path: "{{ mongo_auth_keyfile_destination }}"
   when:
     - inventory_hostname == groups['mongodb'][0]
     - mongodb_replication | bool
   run_once: true
-  ansible.builtin.stat:
-    path: "{{ mongo_auth_keyfile_destination }}"
   register: keyfile_stat
 
 - name: Generate key (if missing) and copy to all nodes

--- a/roles/mongodb_auth/tasks/main.yml
+++ b/roles/mongodb_auth/tasks/main.yml
@@ -4,15 +4,6 @@
 # When authorization is enabled in mongo using a replica set, the members of
 # the set will be required to authenticate too. This is accomplished with a
 # keyFile or x509 certificate. It is assumed that this keyFile already exists.
-- name: Upload the key file if this is a replica set
-  ansible.builtin.copy:
-    src: "{{ mongo_auth_keyfile_source }}"
-    dest: "{{ mongo_auth_keyfile_destination }}"
-    mode: '0400'
-    group: "{{ mongo_group }}"
-    owner: "{{ mongo_owner }}"
-  when: mongodb_replication | bool
-
 - name: Modify mongod.conf to enable authorization
   ansible.builtin.lineinfile:
     path: "{{ mongo_conf_file }}"
@@ -26,6 +17,46 @@
     regexp: "^  #keyFile: /etc/ssl/"
     line: "  keyFile: {{ mongo_auth_keyfile_destination }}"
   when: mongodb_replication | bool
+
+- name: Check if key exists on the first node
+  when:
+    - inventory_hostname == groups['mongodb'][0]
+    - mongodb_replication | bool
+  run_once: true
+  ansible.builtin.stat:
+    path: "{{ mongo_auth_keyfile_destination }}"
+  register: keyfile_stat
+
+- name: Generate key (if missing) and copy to all nodes
+  when:
+    - inventory_hostname == groups['mongodb'][0]
+    - mongodb_replication | bool
+    - not keyfile_stat.stat.exists
+  run_once: true
+  block:
+    - name: Generate a new replica set key with OpenSSL
+      ansible.builtin.shell:
+        cmd: openssl rand -base64 756 > "{{ mongo_auth_keyfile_destination }}"
+      args:
+        creates: "{{ mongo_auth_keyfile_destination }}"
+
+    - name: Set key file ownership and permissions
+      ansible.builtin.file:
+        path: "{{ mongo_auth_keyfile_destination }}"
+        owner: "{{ mongo_owner }}"
+        group: "{{ mongo_group }}"
+        mode: '0400'
+
+    - name: Copy the generated key to all MongoDB nodes
+      ansible.builtin.copy:
+        src: "{{ mongo_auth_keyfile_destination }}"
+        dest: "{{ mongo_auth_keyfile_destination }}"
+        remote_src: true
+        owner: "{{ mongo_owner }}"
+        group: "{{ mongo_group }}"
+        mode: '0400'
+      loop: "{{ groups['mongodb'] }}"
+      delegate_to: "{{ item }}"
 
 - name: Check the auth status
   ansible.builtin.include_role:


### PR DESCRIPTION
The system will create a mongo-key file in /etc/ssl when you enable replication and authentication in mongo.