### PR TITLE
Use dnf for offline platform packages install

### DIFF
--- a/roles/platform/tasks/install-platform.yml
+++ b/roles/platform/tasks/install-platform.yml
@@ -69,6 +69,4 @@
     tasks_from: install-rpms
   vars:
     offline_rpms_path: "{{ platform_offline_control_node_rpms_dir }}/platform"
-    offline_use_rpm_cmd: true
-    offline_rpm_cmd_opts: --noscripts
   when: offline_install_enabled


### PR DESCRIPTION
Product removed the pip installs from the Platform RPMs.  So now we can go back to using the `dnf` module for the installs instead of using `rpm install --noscripts`.