### PR TITLE
Changed logic for add users to database task

### DIFF
--- a/roles/mongodb/tasks/install-mongodb.yml
+++ b/roles/mongodb/tasks/install-mongodb.yml
@@ -105,7 +105,7 @@
 
 - name: Add users to database
   when:
-    - inventory_hostname not in groups.mongodb_arbiter
+    - inventory_hostname in groups.mongodb
     - groups.mongodb.index(inventory_hostname) == 0
   tags: create_mongo_users
   block:


### PR DESCRIPTION
Previous logic would fail if there were no arbiters since the mongodb_arbiter group didn't exist. This solution now checks the mongo group which should always exist.