### PR TITLE
Add new property with default value

### DIFF
--- a/roles/gateway/templates/properties.4.3.yml.j2
+++ b/roles/gateway/templates/properties.4.3.yml.j2
@@ -89,6 +89,10 @@ http_logging_level: INFO
 #          variable from your host's variables "{% raw %}{{commands}}{% endraw %}", etc.
 strict_args: true
 
+# Enabling this property masks the device variables "password" and "ansible_password" in any GET
+# request response for any device type.
+mask_device_passwords: true
+
 ################
 # SSL Settings #
 ################


### PR DESCRIPTION
Enabling this property masks the device inventory variables "password" and "ansible_password" in any GET request response for any device type. This will mask these properties in downstream applications also, like config manager.