### PR TITLE
Add disclaimer to vault role, its not intended for production use

### DIFF
--- a/docs/vault_guide.md
+++ b/docs/vault_guide.md
@@ -14,7 +14,7 @@ generating the root key for the server, and enabling the KV secrets engine used 
 Platform secrets.
 
 This role should not be used on production as it does not follow robust security practices. It is
-intended to for development environments as an integration testing point. The root token and the
+intended for development environments as an integration testing point. The root token and the
 unseal keys are written to the local file system. They must be backed up and considered carefully.
 
 ## Variables

--- a/docs/vault_guide.md
+++ b/docs/vault_guide.md
@@ -13,6 +13,10 @@ required to setup the Vault server. Steps include initializing the server, unsea
 generating the root key for the server, and enabling the KV secrets engine used to store Itential
 Platform secrets.
 
+This role should not be used on production as it does not follow robust security practices. It is
+intended to for development environments as an integration testing point. The root token and the
+unseal keys are written to the local file system. They must be backed up and considered carefully.
+
 ## Variables
 
 ### Static Variables

--- a/docs/vault_guide.md
+++ b/docs/vault_guide.md
@@ -13,9 +13,10 @@ required to setup the Vault server. Steps include initializing the server, unsea
 generating the root key for the server, and enabling the KV secrets engine used to store Itential
 Platform secrets.
 
-This role should not be used on production as it does not follow robust security practices. It is
-intended for development environments as an integration testing point. The root token and the
-unseal keys are written to the local file system. They must be backed up and considered carefully.
+[!WARNING] This role should not be used on production as it does not follow robust security
+practices. It is intended for development environments as an integration testing point. The
+root token and the unseal keys are written to the local file system. They must be backed up and
+considered carefully.
 
 ## Variables
 


### PR DESCRIPTION
Add disclaimer that explains why the Vault role is not suited for production use. Its intended to be used in non-production environments due to its inherent insecurities.