### PR TITLE
Optimize ansible config paths

### DIFF
--- a/roles/gateway/templates/properties.2023.1.yml.j2
+++ b/roles/gateway/templates/properties.2023.1.yml.j2
@@ -248,18 +248,18 @@ inventory_file: "{{ gateway_install_dir }}/ansible/inventory/hosts"
 # NOTE: Use only the site-packages paths you need for your installation to avoid
 #       cross environment issues in the case where multiple of these paths exist
 module_path:
-  - "{{ gateway_install_dir }}/venv/lib/python3.9/site-packages/ansible/modules/network"
   - "{{ gateway_install_dir }}/venv/lib/python3.9/site-packages/ansible/modules"
+  - "{{ gateway_install_dir }}/ansible/modules"
 
 # Path(s) to the Ansible collections that should be discovered by Automation Gateway and exclusively used in Ansible's execution environment.
 # Due to differences in collections before/after Ansible 2.9, these will be the only paths relevant during discovery AND execution.
 collection_path:
   - "{{ gateway_install_dir }}/ansible/collections"
-  - "{{ gateway_install_dir }}/venv/lib/python3.9/site-packages/ansible_collections"
 
 # Path(s) to the Ansible roles that should be discovered by Automation Gateway and appended to Ansible's execution environment.
 role_path:
   - "{{ gateway_install_dir }}/venv/lib/python3.9/site-packages/automation_gateway/integrations/roles"
+  - "{{ gateway_install_dir }}/ansible/roles"
 
 # Path(s) to customized roles that extend device support of the Itential roles found in the release, i.e., itential_cli, itential_get_config.
 #extended_device_role_path:
@@ -274,6 +274,7 @@ playbook_recursive: true
 # Path(s) to the Ansible playbooks that should be discovered by Automation Gateway and appended to Ansible's execution environment.
 playbook_path:
   - "{{ gateway_install_dir }}/venv/lib/python3.9/site-packages/automation_gateway/integrations/playbooks"
+  - "{{ gateway_install_dir }}/ansible/playbooks"
 
 #################
 # HTTP_Requests #

--- a/roles/gateway/templates/properties.2023.2.yml.j2
+++ b/roles/gateway/templates/properties.2023.2.yml.j2
@@ -248,18 +248,18 @@ inventory_file: "{{ gateway_install_dir }}/ansible/inventory/hosts"
 # NOTE: Use only the site-packages paths you need for your installation to avoid
 #       cross environment issues in the case where multiple of these paths exist
 module_path:
-  - "{{ gateway_install_dir }}/venv/lib/python{{ gateway_python_version }}/site-packages/ansible/modules/network"
   - "{{ gateway_install_dir }}/venv/lib/python{{ gateway_python_version }}/site-packages/ansible/modules"
+  - "{{ gateway_install_dir }}/ansible/modules"
 
 # Path(s) to the Ansible collections that should be discovered by Automation Gateway and exclusively used in Ansible's execution environment.
 # Due to differences in collections before/after Ansible 2.9, these will be the only paths relevant during discovery AND execution.
 collection_path:
   - "{{ gateway_install_dir }}/ansible/collections"
-  - "{{ gateway_install_dir }}/venv/lib/python{{ gateway_python_version }}/site-packages/ansible_collections"
 
 # Path(s) to the Ansible roles that should be discovered by Automation Gateway and appended to Ansible's execution environment.
 role_path:
   - "{{ gateway_install_dir }}/venv/lib/python{{ gateway_python_version }}/site-packages/automation_gateway/integrations/roles"
+  - "{{ gateway_install_dir }}/ansible/roles"
 
 # Path(s) to customized roles that extend device support of the Itential roles found in the release, i.e., itential_cli, itential_get_config.
 #extended_device_role_path:
@@ -274,6 +274,7 @@ playbook_recursive: true
 # Path(s) to the Ansible playbooks that should be discovered by Automation Gateway and appended to Ansible's execution environment.
 playbook_path:
   - "{{ gateway_install_dir }}/venv/lib/python{{ gateway_python_version }}/site-packages/automation_gateway/integrations/playbooks"
+  - "{{ gateway_install_dir }}/ansible/playbooks"
 
 #################
 # HTTP_Requests #

--- a/roles/gateway/templates/properties.2023.3.yml.j2
+++ b/roles/gateway/templates/properties.2023.3.yml.j2
@@ -266,20 +266,20 @@ inventory_file: '{{ gateway_install_dir }}/ansible/inventory/hosts'
 # NOTE: Use only the site-packages paths you need for your installation to avoid
 #       cross environment issues in the case where multiple of these paths exist
 module_path:
-  - "{{ gateway_install_dir }}/venv/lib/python{{ gateway_python_version }}/site-packages/ansible/modules/network"
   - "{{ gateway_install_dir }}/venv/lib/python{{ gateway_python_version }}/site-packages/ansible/modules"
+  - "{{ gateway_install_dir }}/ansible/modules"
 
 # Path(s) to the Ansible collections that should be discovered by Automation Gateway and
 # exclusively used in Ansible's execution environment. Due to differences in collections
 # before/after Ansible 2.9, these will be the only paths relevant during discovery AND execution.
 collection_path:
   - "{{ gateway_install_dir }}/ansible/collections"
-  - "{{ gateway_install_dir }}/venv/lib/python{{ gateway_python_version }}/site-packages/ansible_collections"
 
 # Path(s) to the Ansible roles that should be discovered by Automation Gateway and appended to
 # Ansible's execution environment.
 role_path:
   - "{{ gateway_install_dir }}/venv/lib/python{{ gateway_python_version }}/site-packages/automation_gateway/integrations/roles"
+  - "{{ gateway_install_dir }}/ansible/roles"
 
 # Path(s) to customized roles that extend device support of the Itential roles found in the release,
 # i.e., itential_cli, itential_get_config.
@@ -296,6 +296,7 @@ playbook_recursive: true
 # Ansible's execution environment.
 playbook_path:
   - "{{ gateway_install_dir }}/venv/lib/python{{ gateway_python_version }}/site-packages/automation_gateway/integrations/playbooks"
+  - "{{ gateway_install_dir }}/ansible/playbooks"
 
 #################
 # HTTP_Requests #

--- a/roles/gateway/templates/properties.4.3.yml.j2
+++ b/roles/gateway/templates/properties.4.3.yml.j2
@@ -270,20 +270,20 @@ inventory_file: '{{ gateway_install_dir }}/ansible/inventory/hosts'
 # NOTE: Use only the site-packages paths you need for your installation to avoid
 #       cross environment issues in the case where multiple of these paths exist
 module_path:
-  - "{{ gateway_install_dir }}/venv/lib/python{{ gateway_python_version }}/site-packages/ansible/modules/network"
   - "{{ gateway_install_dir }}/venv/lib/python{{ gateway_python_version }}/site-packages/ansible/modules"
+  - "{{ gateway_install_dir }}/ansible/modules"
 
 # Path(s) to the Ansible collections that should be discovered by Automation Gateway and
 # exclusively used in Ansible's execution environment. Due to differences in collections
 # before/after Ansible 2.9, these will be the only paths relevant during discovery AND execution.
 collection_path:
   - "{{ gateway_install_dir }}/ansible/collections"
-  - "{{ gateway_install_dir }}/venv/lib/python{{ gateway_python_version }}/site-packages/ansible_collections"
 
 # Path(s) to the Ansible roles that should be discovered by Automation Gateway and appended to
 # Ansible's execution environment.
 role_path:
   - "{{ gateway_install_dir }}/venv/lib/python{{ gateway_python_version }}/site-packages/automation_gateway/integrations/roles"
+  - "{{ gateway_install_dir }}/ansible/roles"
 
 # Path(s) to customized roles that extend device support of the Itential roles found in the release,
 # i.e., itential_cli, itential_get_config.
@@ -300,6 +300,7 @@ playbook_recursive: true
 # Ansible's execution environment.
 playbook_path:
   - "{{ gateway_install_dir }}/venv/lib/python{{ gateway_python_version }}/site-packages/automation_gateway/integrations/playbooks"
+  - "{{ gateway_install_dir }}/ansible/playbooks"
 
 #################
 # HTTP_Requests #


### PR DESCRIPTION
Optimize the ansible config to avoid an unnecessary amount of ansible assets getting converted into task definitions.