### PR TITLE
Add assertion tasks to deployer roles

### DIFF
--- a/playbooks/nginx_configure.yml
+++ b/playbooks/nginx_configure.yml
@@ -54,3 +54,16 @@
       ansible.builtin.debug:
         msg:
           - "Nginx service status: {{ nginx_service_status.status.ActiveState }}"
+
+    - name: Assert that nginx is running
+      block:
+        - name: Get nginx service status
+          ansible.builtin.systemd:
+            name: nginx
+          register: nginx_status
+
+        - name: Assert that nginx is running
+          ansible.builtin.assert:
+            that: nginx_status.status.ActiveState == "active"
+            fail_msg: "Nginx service is not running (state: {{ nginx_status.status.ActiveState }})"
+            success_msg: "Nginx service is running correctly"

--- a/playbooks/nginx_install.yml
+++ b/playbooks/nginx_install.yml
@@ -15,3 +15,16 @@
         name: nginx
         state: restarted
         enabled: true
+
+    - name: Assert that nginx is running
+      block:
+        - name: Get nginx service status
+          ansible.builtin.systemd:
+            name: nginx
+          register: nginx_status
+
+        - name: Assert that nginx is running
+          ansible.builtin.assert:
+            that: nginx_status.status.ActiveState == "active"
+            fail_msg: "Nginx service is not running (state: {{ nginx_status.status.ActiveState }})"
+            success_msg: "Nginx service is running correctly"

--- a/roles/gateway/tasks/main.yml
+++ b/roles/gateway/tasks/main.yml
@@ -368,6 +368,19 @@
     state: restarted
     daemon_reload: true
 
+- name: Assert that Automation Gateway is running
+  block:
+    - name: Get Automation Gateway service status
+      ansible.builtin.service:
+        name: automation-gateway
+      register: gateway_status
+
+    - name: Assert that Automation Gateway is running
+      ansible.builtin.assert:
+        that: gateway_status.status.ActiveState == "active"
+        fail_msg: "Automation Gateway service is not running (state: {{ gateway_status.status.ActiveState }})"
+        success_msg: "Automation Gateway service is running correctly"
+
 - name: Update release file
   ansible.builtin.include_tasks:
     file: update-release-file.yml

--- a/roles/gateway/tasks/upgrade-gateway.yml
+++ b/roles/gateway/tasks/upgrade-gateway.yml
@@ -71,6 +71,19 @@
     enabled: true
     state: restarted
 
+- name: Assert that Automation Gateway is running
+  block:
+    - name: Get Automation Gateway service status
+      ansible.builtin.service:
+        name: automation-gateway
+      register: gateway_status
+
+    - name: Assert that Automation Gateway is running
+      ansible.builtin.assert:
+        that: gateway_status.status.ActiveState == "active"
+        fail_msg: "Automation Gateway service is not running (state: {{ gateway_status.status.ActiveState }})"
+        success_msg: "Automation Gateway service is running correctly"
+
 - name: Remove temporary working directory
   ansible.builtin.file:
     path: "{{ workingdir.path }}"

--- a/roles/gateway_haproxy/tasks/main.yml
+++ b/roles/gateway_haproxy/tasks/main.yml
@@ -42,3 +42,21 @@
     name: haproxy
     enabled: false
     state: restarted
+
+- name: Assert that HAProxy is running
+  block:
+    - name: Get HAProxy service status
+      ansible.builtin.service:
+        name: haproxy
+      register: gateway_haproxy_status
+
+    - name: Assert that HAProxy is running
+      ansible.builtin.assert:
+        that: gateway_haproxy_status.status.ActiveState == "active"
+        fail_msg: "HAProxy service is not running (state: {{ gateway_haproxy_status.status.ActiveState }})"
+        success_msg: "HAProxy service is running correctly"
+
+- name: Remove temporary working directory
+  ansible.builtin.file:
+    path: "{{ workingdir.path }}"
+    state: absent

--- a/roles/gateway_haproxy/tasks/main.yml
+++ b/roles/gateway_haproxy/tasks/main.yml
@@ -55,8 +55,3 @@
         that: gateway_haproxy_status.status.ActiveState == "active"
         fail_msg: "HAProxy service is not running (state: {{ gateway_haproxy_status.status.ActiveState }})"
         success_msg: "HAProxy service is running correctly"
-
-- name: Remove temporary working directory
-  ansible.builtin.file:
-    path: "{{ workingdir.path }}"
-    state: absent

--- a/roles/grafana/tasks/main.yml
+++ b/roles/grafana/tasks/main.yml
@@ -78,3 +78,16 @@
     name: grafana-server
     state: restarted
     enabled: true
+
+- name: Assert that Grafana is running
+  block:
+    - name: Get Grafana service status
+      ansible.builtin.systemd:
+        name: grafana-server
+      register: grafana_status
+
+    - name: Assert that Grafana is running
+      ansible.builtin.assert:
+        that: grafana_status.status.ActiveState == "active"
+        fail_msg: "Grafana service is not running (state: {{ grafana_status.status.ActiveState }})"
+        success_msg: "Grafana service is running correctly"

--- a/roles/mongodb/tasks/configure-mongodb-auth.yml
+++ b/roles/mongodb/tasks/configure-mongodb-auth.yml
@@ -76,3 +76,16 @@
     name: mongod
     state: restarted
     enabled: true
+
+- name: Assert that MongoDB is running
+  block:
+    - name: Get MongoDB service status
+      ansible.builtin.systemd:
+        name: mongod
+      register: mongodb_status
+
+    - name: Assert that MongoDB is running
+      ansible.builtin.assert:
+        that: mongodb_status.status.ActiveState == "active"
+        fail_msg: "MongoDB service is not running (state: {{ mongodb_status.status.ActiveState }})"
+        success_msg: "MongoDB service is running correctly"

--- a/roles/mongodb/tasks/configure-mongodb-replicaset.yml
+++ b/roles/mongodb/tasks/configure-mongodb-replicaset.yml
@@ -49,6 +49,20 @@
     enabled: true
   when: not mongodb_state.replication_enabled
 
+- name: Assert that MongoDB is running
+  when: not mongodb_state.replication_enabled
+  block:
+    - name: Get MongoDB service status
+      ansible.builtin.systemd:
+        name: mongod
+      register: mongodb_status
+
+    - name: Assert that MongoDB is running
+      ansible.builtin.assert:
+        that: mongodb_status.status.ActiveState == "active"
+        fail_msg: "MongoDB service is not running (state: {{ mongodb_status.status.ActiveState }})"
+        success_msg: "MongoDB service is running correctly"
+
 - name: Set empty array of mongo servers
   ansible.builtin.set_fact:
     mongodb_servers: []

--- a/roles/mongodb/tasks/configure-mongodb-tls.yml
+++ b/roles/mongodb/tasks/configure-mongodb-tls.yml
@@ -45,3 +45,16 @@
     name: mongod
     state: restarted
     enabled: true
+
+- name: Assert that MongoDB is running
+  block:
+    - name: Get MongoDB service status
+      ansible.builtin.systemd:
+        name: mongod
+      register: mongodb_status
+
+    - name: Assert that MongoDB is running
+      ansible.builtin.assert:
+        that: mongodb_status.status.ActiveState == "active"
+        fail_msg: "MongoDB service is not running (state: {{ mongodb_status.status.ActiveState }})"
+        success_msg: "MongoDB service is running correctly"

--- a/roles/mongodb/tasks/install-mongodb.yml
+++ b/roles/mongodb/tasks/install-mongodb.yml
@@ -108,6 +108,20 @@
     enabled: true
   tags: initialize_mongo_config
 
+- name: Assert that MongoDB is running
+  tags: initialize_mongo_config
+  block:
+    - name: Get MongoDB service status
+      ansible.builtin.systemd:
+        name: mongod
+      register: mongodb_status
+
+    - name: Assert that MongoDB is running
+      ansible.builtin.assert:
+        that: mongodb_status.status.ActiveState == "active"
+        fail_msg: "MongoDB service is not running (state: {{ mongodb_status.status.ActiveState }})"
+        success_msg: "MongoDB service is running correctly"
+
 - name: Add users to database
   when: inventory_hostname == groups['mongodb'][0]
   tags: create_mongo_users

--- a/roles/platform/tasks/install-adapters.yml
+++ b/roles/platform/tasks/install-adapters.yml
@@ -124,11 +124,11 @@
         mode: '0644'
       loop: "{{ adapter_names }}"
 
-- name: Flush all handlers
-  ansible.builtin.meta: flush_handlers
-
 - name: Ensure Itential Platform is running
   block:
+    - name: Flush all handlers
+      ansible.builtin.meta: flush_handlers
+
     - name: Start Itential Platform
       ansible.builtin.systemd:
         name: itential-platform

--- a/roles/platform/tasks/install-adapters.yml
+++ b/roles/platform/tasks/install-adapters.yml
@@ -123,3 +123,27 @@
         create: true
         mode: '0644'
       loop: "{{ adapter_names }}"
+
+- name: Flush all handlers
+  ansible.builtin.meta: flush_handlers
+
+- name: Ensure Itential Platform is running
+  tags: always
+  block:
+    - name: Start Itential Platform
+      ansible.builtin.systemd:
+        name: itential-platform
+        state: started
+
+    - name: Assert that Itential Platform is running
+      block:
+        - name: Get Itential Platform service status
+          ansible.builtin.systemd:
+            name: itential-platform
+          register: platform_status
+
+        - name: Assert that Itential Platform is running
+          ansible.builtin.assert:
+            that: platform_status.status.ActiveState == "active"
+            fail_msg: "Itential Platform service is not running (state: {{ platform_status.status.ActiveState }})"
+            success_msg: "Itential Platform service is running correctly"

--- a/roles/platform/tasks/install-adapters.yml
+++ b/roles/platform/tasks/install-adapters.yml
@@ -128,7 +128,6 @@
   ansible.builtin.meta: flush_handlers
 
 - name: Ensure Itential Platform is running
-  tags: always
   block:
     - name: Start Itential Platform
       ansible.builtin.systemd:

--- a/roles/platform/tasks/install-app-artifacts.yml
+++ b/roles/platform/tasks/install-app-artifacts.yml
@@ -49,12 +49,11 @@
           changed_when: result.rc == 0
           failed_when: result.rc > 0
 
-- name: Flush all handlers
-  ansible.builtin.meta: flush_handlers
-
 - name: Ensure Itential Platform is running
-  tags: always
   block:
+    - name: Flush all handlers
+      ansible.builtin.meta: flush_handlers
+
     - name: Start Itential Platform
       ansible.builtin.systemd:
         name: itential-platform

--- a/roles/platform/tasks/install-app-artifacts.yml
+++ b/roles/platform/tasks/install-app-artifacts.yml
@@ -48,3 +48,27 @@
           register: result
           changed_when: result.rc == 0
           failed_when: result.rc > 0
+
+- name: Flush all handlers
+  ansible.builtin.meta: flush_handlers
+
+- name: Ensure Itential Platform is running
+  tags: always
+  block:
+    - name: Start Itential Platform
+      ansible.builtin.systemd:
+        name: itential-platform
+        state: started
+
+    - name: Assert that Itential Platform is running
+      block:
+        - name: Get Itential Platform service status
+          ansible.builtin.systemd:
+            name: itential-platform
+          register: platform_status
+
+        - name: Assert that Itential Platform is running
+          ansible.builtin.assert:
+            that: platform_status.status.ActiveState == "active"
+            fail_msg: "Itential Platform service is not running (state: {{ platform_status.status.ActiveState }})"
+            success_msg: "Itential Platform service is running correctly"

--- a/roles/platform/tasks/main.yml
+++ b/roles/platform/tasks/main.yml
@@ -115,3 +115,27 @@
         - name: Configure Platform
           ansible.builtin.include_tasks:
             file: configure-platform.yml
+
+- name: Flush all handlers
+  ansible.builtin.meta: flush_handlers
+
+- name: Ensure Itential Platform is running
+  tags: always
+  block:
+    - name: Start Itential Platform
+      ansible.builtin.systemd:
+        name: itential-platform
+        state: started
+
+    - name: Assert that Itential Platform is running
+      block:
+        - name: Get Itential Platform service status
+          ansible.builtin.systemd:
+            name: itential-platform
+          register: platform_status
+
+        - name: Assert that Itential Platform is running
+          ansible.builtin.assert:
+            that: platform_status.status.ActiveState == "active"
+            fail_msg: "Itential Platform service is not running (state: {{ platform_status.status.ActiveState }})"
+            success_msg: "Itential Platform service is running correctly"

--- a/roles/platform/tasks/main.yml
+++ b/roles/platform/tasks/main.yml
@@ -116,12 +116,11 @@
           ansible.builtin.include_tasks:
             file: configure-platform.yml
 
-- name: Flush all handlers
-  ansible.builtin.meta: flush_handlers
-
 - name: Ensure Itential Platform is running
-  tags: always
   block:
+    - name: Flush all handlers
+      ansible.builtin.meta: flush_handlers
+
     - name: Start Itential Platform
       ansible.builtin.systemd:
         name: itential-platform

--- a/roles/prometheus/tasks/main.yml
+++ b/roles/prometheus/tasks/main.yml
@@ -17,3 +17,27 @@
         group: "{{ prometheus_system_group }}"
         mode: "0644"
         lstrip_blocks: true
+
+- name: Flush all handlers
+  ansible.builtin.meta: flush_handlers
+
+- name: Ensure Prometheus is running
+  tags: always
+  block:
+    - name: Start Prometheus
+      ansible.builtin.systemd:
+        name: prometheus
+        state: started
+
+    - name: Assert that Prometheus is running
+      block:
+        - name: Get Prometheus service status
+          ansible.builtin.systemd:
+            name: prometheus
+          register: prometheus_status
+
+        - name: Assert that Prometheus is running
+          ansible.builtin.assert:
+            that: prometheus_status.status.ActiveState == "active"
+            fail_msg: "Prometheus service is not running (state: {{ prometheus_status.status.ActiveState }})"
+            success_msg: "Prometheus service is running correctly"

--- a/roles/prometheus/tasks/main.yml
+++ b/roles/prometheus/tasks/main.yml
@@ -18,12 +18,11 @@
         mode: "0644"
         lstrip_blocks: true
 
-- name: Flush all handlers
-  ansible.builtin.meta: flush_handlers
-
 - name: Ensure Prometheus is running
-  tags: always
   block:
+    - name: Flush all handlers
+      ansible.builtin.meta: flush_handlers
+
     - name: Start Prometheus
       ansible.builtin.systemd:
         name: prometheus

--- a/roles/redis/tasks/main.yml
+++ b/roles/redis/tasks/main.yml
@@ -59,12 +59,11 @@
             file: configure-sentinel.yml
           when: redis_replication_enabled | bool
 
-- name: Flush all handlers
-  ansible.builtin.meta: flush_handlers
-
 - name: Ensure Redis is running
-  tags: always
   block:
+    - name: Flush all handlers
+      ansible.builtin.meta: flush_handlers
+
     - name: Start Redis
       ansible.builtin.systemd:
         name: redis

--- a/roles/redis/tasks/main.yml
+++ b/roles/redis/tasks/main.yml
@@ -58,3 +58,48 @@
           ansible.builtin.include_tasks:
             file: configure-sentinel.yml
           when: redis_replication_enabled | bool
+
+- name: Flush all handlers
+  ansible.builtin.meta: flush_handlers
+
+- name: Ensure Redis is running
+  tags: always
+  block:
+    - name: Start Redis
+      ansible.builtin.systemd:
+        name: redis
+        state: started
+
+    - name: Assert that Redis is running
+      block:
+        - name: Get Redis service status
+          ansible.builtin.systemd:
+            name: redis
+          register: redis_status
+
+        - name: Assert that Redis is running
+          ansible.builtin.assert:
+            that: redis_status.status.ActiveState == "active"
+            fail_msg: "Redis service is not running (state: {{ redis_status.status.ActiveState }})"
+            success_msg: "Redis service is running correctly"
+
+- name: Ensure Sentinel is running
+  when: redis_replication_enabled | bool
+  block:
+    - name: Start Sentinel
+      ansible.builtin.systemd:
+        name: redis-sentinel
+        state: started
+
+    - name: Assert that Sentinel is running
+      block:
+        - name: Get Sentinel service status
+          ansible.builtin.systemd:
+            name: redis-sentinel
+          register: redis_sentinel_status
+
+        - name: Assert that Sentinel is running
+          ansible.builtin.assert:
+            that: redis_sentinel_status.status.ActiveState == "active"
+            fail_msg: "Sentinel service is not running (state: {{ redis_sentinel_status.status.ActiveState }})"
+            success_msg: "Sentinel service is running correctly"

--- a/roles/vault/tasks/main.yml
+++ b/roles/vault/tasks/main.yml
@@ -36,6 +36,26 @@
 - name: Restart Vault if needed
   ansible.builtin.meta: flush_handlers
 
+- name: Ensure Vault is running
+  block:
+    - name: Start Vault
+      ansible.builtin.systemd:
+        name: vault
+        state: started
+
+    - name: Assert that Vault is running
+      block:
+        - name: Get Vault service status
+          ansible.builtin.systemd:
+            name: vault
+          register: vault_status
+
+        - name: Assert that Vault is running
+          ansible.builtin.assert:
+            that: vault_status.status.ActiveState == "active"
+            fail_msg: "Vault service is not running (state: {{ vault_status.status.ActiveState }})"
+            success_msg: "Vault service is running correctly"
+
 - name: Unseal Vault
   tags: unseal_vault
   block:


### PR DESCRIPTION
Added assertion tasks after each task that starts a systemd service, in order to ensure that the service is actually running.

The only systemd tasks that assertions are not included for are the ones that launch services for enabling/disabling transparent hugepages, as these are oneshot services that immediately become inactive. All other systemd services started by the deployer should be covered by this PR.