### PR TITLE
Modified recommended http server threads comment per IAG performance tests

### DIFF
--- a/roles/gateway/templates/properties.2021.1.yml.j2
+++ b/roles/gateway/templates/properties.2021.1.yml.j2
@@ -29,7 +29,8 @@ bind_address: {{ inventory_hostname }}
 # external_address: 'http://automation-gateway.example.com:8080'
 
 # The number of http server threads for handling requests.
-# A good starting point is 2-4 x NUM_CORES then adjust based on observed workload.
+# It is recommended to set this to 4 x NUM_CORES.
+# E.g. for a 16 core machine, the value should be set to 64.
 http_server_threads: {{ gateway_http_server_threads }}
 
 # A flag that determines whether authentication is disabled or not.

--- a/roles/gateway/templates/properties.2021.2.yml.j2
+++ b/roles/gateway/templates/properties.2021.2.yml.j2
@@ -29,7 +29,8 @@ bind_address: {{ inventory_hostname }}
 # external_address: 'http://automation-gateway.example.com:8080'
 
 # The number of http server threads for handling requests.
-# A good starting point is 2-4 x NUM_CORES then adjust based on observed workload.
+# It is recommended to set this to 4 x NUM_CORES.
+# E.g. for a 16 core machine, the value should be set to 64.
 http_server_threads: {{ gateway_http_server_threads }}
 
 # A flag that determines whether authentication is disabled or not.

--- a/roles/gateway/templates/properties.2022.1.yml.j2
+++ b/roles/gateway/templates/properties.2022.1.yml.j2
@@ -29,7 +29,8 @@ bind_address: {{ inventory_hostname }}
 # external_address: 'http://automation-gateway.example.com:8080'
 
 # The number of http server threads for handling requests.
-# A good starting point is 2-4 x NUM_CORES then adjust based on observed workload.
+# It is recommended to set this to 4 x NUM_CORES.
+# E.g. for a 16 core machine, the value should be set to 64.
 http_server_threads: {{ gateway_http_server_threads }}
 
 # A flag that determines whether authentication is disabled or not.

--- a/roles/gateway/templates/properties.2023.1.yml.j2
+++ b/roles/gateway/templates/properties.2023.1.yml.j2
@@ -33,7 +33,8 @@ bind_address: {{ inventory_hostname }}
 # external_address: 'http://automation-gateway.example.com:8080'
 
 # The number of http server threads for handling requests.
-# A good starting point is 2-4 x NUM_CORES then adjust based on observed workload.
+# It is recommended to set this to 4 x NUM_CORES.
+# E.g. for a 16 core machine, the value should be set to 64.
 http_server_threads: {{ gateway_http_server_threads }}
 
 # A flag that determines whether authentication is disabled or not.

--- a/roles/gateway/templates/properties.2023.2.yml.j2
+++ b/roles/gateway/templates/properties.2023.2.yml.j2
@@ -33,7 +33,8 @@ bind_address: {{ inventory_hostname }}
 # external_address: 'http://automation-gateway.example.com:8080'
 
 # The number of http server threads for handling requests.
-# A good starting point is 2-4 x NUM_CORES then adjust based on observed workload.
+# It is recommended to set this to 4 x NUM_CORES.
+# E.g. for a 16 core machine, the value should be set to 64.
 http_server_threads: {{ gateway_http_server_threads }}
 
 # A flag that determines whether authentication is disabled or not.

--- a/roles/gateway/templates/properties.2023.3.yml.j2
+++ b/roles/gateway/templates/properties.2023.3.yml.j2
@@ -47,7 +47,8 @@ bind_address: {{ inventory_hostname }}
 # external_address: 'http://automation-gateway.example.com:8080'
 
 # The number of http server threads for handling requests.
-# A good starting point is 2-4 x NUM_CORES then adjust based on observed workload.
+# It is recommended to set this to 4 x NUM_CORES.
+# E.g. for a 16 core machine, the value should be set to 64.
 http_server_threads: {{ gateway_http_server_threads }}
 
 # A flag that determines whether authentication is disabled or not.

--- a/roles/gateway/templates/properties.4.3.yml.j2
+++ b/roles/gateway/templates/properties.4.3.yml.j2
@@ -47,7 +47,8 @@ bind_address: {{ inventory_hostname }}
 # external_address: 'http://automation-gateway.example.com:8080'
 
 # The number of http server threads for handling requests.
-# A good starting point is 2-4 x NUM_CORES then adjust based on observed workload.
+# It is recommended to set this to 4 x NUM_CORES.
+# E.g. for a 16 core machine, the value should be set to 64.
 http_server_threads: {{ gateway_http_server_threads }}
 
 # A flag that determines whether authentication is disabled or not.


### PR DESCRIPTION
Modifying the description for the `http_server_threads` system configuration setting in the`properties.yml` templates for IAG.

This is due to the performance testing data showing a significant increase in performance between `2 X NUM_CORES` and `4 X NUM_CORES` in our testing.

This is also now more inline with the Jinja templating that already takes place to input `4 X NUM_CORES` in for `http_server_threads`.