### PR TITLE
Remove condition that prevents adjusting SELinux labels

### DIFF
--- a/roles/redis/tasks/install-common.yml
+++ b/roles/redis/tasks/install-common.yml
@@ -63,8 +63,7 @@
     owner: "{{ redis_owner }}"
     group: "{{ redis_group }}"
     mode: "0755"
-  when:
-    - (redis_bin_dir != redis_bin_dir_default_packages or
+  when: (redis_bin_dir != redis_bin_dir_default_packages or
        (redis_bin_dir != redis_bin_dir_default_source and redis_install_from_source | bool))
 
 - name: Create Redis data directory
@@ -77,8 +76,7 @@
     seuser: system_u
     serole: object_r
     setype: redis_var_lib_t
-  when:
-    - redis_data_dir != redis_data_dir_default or redis_install_from_source | bool
+  when: redis_data_dir != redis_data_dir_default or redis_install_from_source | bool
 
 - name: Create Redis log directory
   ansible.builtin.file:
@@ -90,8 +88,7 @@
     seuser: system_u
     serole: object_r
     setype: redis_log_t
-  when:
-    - redis_log_dir != redis_log_dir_default or redis_install_from_source | bool
+  when: redis_log_dir != redis_log_dir_default or redis_install_from_source | bool
 
 - name: Create Redis configuration directory
   ansible.builtin.file:
@@ -103,5 +100,4 @@
     seuser: system_u
     serole: object_r
     setype: redis_conf_t
-  when:
-    - redis_conf_dir != redis_conf_dir_default or redis_install_from_source | bool
+  when: redis_conf_dir != redis_conf_dir_default or redis_install_from_source | bool

--- a/roles/redis/tasks/install-common.yml
+++ b/roles/redis/tasks/install-common.yml
@@ -56,11 +56,6 @@
     group: "{{ redis_group }}"
     state: present
 
-- name: Check to see if Redis bin directory exists
-  ansible.builtin.stat:
-    path: "{{ redis_bin_dir }}"
-  register: redis_bin_dir_stat
-
 - name: Create Redis bin directory
   ansible.builtin.file:
     state: directory
@@ -71,12 +66,6 @@
   when:
     - (redis_bin_dir != redis_bin_dir_default_packages or
        (redis_bin_dir != redis_bin_dir_default_source and redis_install_from_source | bool))
-    - not redis_bin_dir_stat.stat.exists
-
-- name: Check to see if Redis data directory exists
-  ansible.builtin.stat:
-    path: "{{ redis_data_dir }}"
-  register: redis_data_dir_stat
 
 - name: Create Redis data directory
   ansible.builtin.file:
@@ -90,12 +79,6 @@
     setype: redis_var_lib_t
   when:
     - redis_data_dir != redis_data_dir_default or redis_install_from_source | bool
-    - not redis_data_dir_stat.stat.exists
-
-- name: Check to see if Redis log directory exists
-  ansible.builtin.stat:
-    path: "{{ redis_log_dir }}"
-  register: redis_log_dir_stat
 
 - name: Create Redis log directory
   ansible.builtin.file:
@@ -109,12 +92,6 @@
     setype: redis_log_t
   when:
     - redis_log_dir != redis_log_dir_default or redis_install_from_source | bool
-    - not redis_log_dir_stat.stat.exists
-
-- name: Check to see if Redis configuration directory exists
-  ansible.builtin.stat:
-    path: "{{ redis_conf_dir }}"
-  register: redis_conf_dir_stat
 
 - name: Create Redis configuration directory
   ansible.builtin.file:
@@ -128,4 +105,3 @@
     setype: redis_conf_t
   when:
     - redis_conf_dir != redis_conf_dir_default or redis_install_from_source | bool
-    - not redis_conf_dir_stat.stat.exists


### PR DESCRIPTION
Under certain conditions the SELinux labels were not getting set. This would cause Redis to fail at startup due to SELinux restrictions. This change removes those conditions and sets the appropriate labels on directories when SELinux is enforcing and non-standard directories are used.