### PR TITLE
Add inventory group-based replica set configuration with priority support

### DIFF
--- a/docs/mongodb_guide.md
+++ b/docs/mongodb_guide.md
@@ -229,10 +229,6 @@ values defined with Platform 6.
 
 ```yaml
 all:
-  vars:
-    repository_api_key: #key
-    platform_release: 6
-
   children:
     mongodb_primary:
       hosts:
@@ -248,9 +244,6 @@ This example shows how to override the default version of MongoDB that is instal
 
 ```yaml
 all:
-  vars:
-    repository_api_key: #key
-
   children:
     mongodb_primary:
       hosts:
@@ -273,10 +266,6 @@ enabled when the `mongodb_replica` group is defined. Place shared variables in `
 
 ```yaml
 all:
-  vars:
-    repository_api_key: #key
-    platform_release: 6
-
   children:
     mongodb_node:
       vars:
@@ -302,10 +291,6 @@ elections but hold no data.
 
 ```yaml
 all:
-  vars:
-    repository_api_key: #key
-    platform_release: 6
-
   children:
     mongodb_node:
       children:
@@ -332,10 +317,6 @@ override the priority individually by setting `mongodb_replica_priority` directl
 
 ```yaml
 all:
-  vars:
-    repository_api_key: #key
-    platform_release: 6
-
   children:
     mongodb_node:
       vars:
@@ -362,10 +343,6 @@ and set it to `true`, and configure the `mongodb_pki_src_dir`.
 
 ```yaml
 all:
-  vars:
-    repository_api_key: #key
-    platform_release: 6
-
   children:
     mongodb_node:
       vars:

--- a/docs/mongodb_guide.md
+++ b/docs/mongodb_guide.md
@@ -83,7 +83,7 @@ The variables in this section are configured in the inventory in the `all` group
 
 | Variable | Group | Type | Description | Default Value |
 | :------- | :---- | :--- | :---------- | :------------ |
-| `platform_release` | `all` | Fixed-point | Designates the IAP major version. If this is not included then the `mongodb_primary` group must specify the MongoDB packages (the precise Mongo version) to install. | N/A |
+| `platform_release` | `all` | Fixed-point | Designates the IAP major version. If this is not included then the `mongodb_primary`, `mongodb_replica` and `mongodb_arbiter` groups must specify the MongoDB packages (the precise Mongo version) to install. | N/A |
 
 When the `platform_release` is defined in the inventory then the playbook will use default values
 for the MongoDB version to install. These defaults are determined by the Itential Platform version

--- a/docs/mongodb_guide.md
+++ b/docs/mongodb_guide.md
@@ -23,12 +23,25 @@ configurations is based on the variables that are set in the host file. See belo
 
 ## MongoDB Replication
 
-When configured to do so, the role is responsible for configuring MongoDB as a replica set.  It uses
-the first host defined in the `mongodb` group in the inventory as the initial primary.  It updates
-the MongoDB configuration file with the replica set name and enables replication.  It initializes
-the replica set on the initial primary and then joins the remaining MongoDB nodes to the replica
-set. It will restart the mongod service when complete. The role will detect if replication has
-already been enabled and skip these tasks if it determines that replication is already enabled.
+When configured to do so, the role is responsible for configuring MongoDB as a replica set. The
+inventory uses two dedicated groups to declare replica set membership and role:
+
+- `mongodb_node` — parent group that contains `mongodb_primary` and `mongodb_replica` as children.
+  Place shared variables (replica set name, auth, TLS, passwords, etc.) here so they apply to all
+  members without duplication.
+- `mongodb_primary` — hosts in this group are configured as preferred primary members with a higher
+  election priority. The first host in this group acts as the coordinator that initiates and
+  reconfigures the replica set.
+- `mongodb_replica` — hosts in this group are configured as secondary members with a lower election
+  priority. Replication is automatically enabled when this group is defined.
+- `mongodb_arbiter` — (optional) hosts in this group are added to the replica set as arbiters with
+  zero priority. Arbiters participate in elections but do not hold data.
+
+The role updates the MongoDB configuration file with the replica set name and enables replication.
+It initializes the replica set from the first `mongodb_primary` host, then joins all remaining
+members. If after initialization the current primary is not the intended primary node, the role will
+step it down to trigger a new election. The role detects if replication has already been enabled and
+reconfigures the existing replica set instead of reinitializing it.
 
 More info on replication: <https://www.mongodb.com/docs/manual/replication/>
 
@@ -70,17 +83,17 @@ The variables in this section are configured in the inventory in the `all` group
 
 | Variable | Group | Type | Description | Default Value |
 | :------- | :---- | :--- | :---------- | :------------ |
-| `platform_release` | `all` | Fixed-point | Designates the IAP major version. If this is not included then the `mongodb` device group must specify the MongoDB packages (the precise Mongo version) to install. | N/A |
+| `platform_release` | `all` | Fixed-point | Designates the IAP major version. If this is not included then the `mongodb_primary` group must specify the MongoDB packages (the precise Mongo version) to install. | N/A |
 
 When the `platform_release` is defined in the inventory then the playbook will use default values
 for the MongoDB version to install. These defaults are determined by the Itential Platform version
-and represent our validated design. If this is not included then the `mongodb` device group must
+and represent our validated design. If this is not included then the `mongodb_primary` group must
 specify the MongoDB packages (the precise Mongo version) to install. See below an example of how to
 override the default MongoDB version.
 
 ### MongoDB Role Variables
 
-The variables in this section may be overridden in the inventory in the `mongodb` group vars.
+The variables in this section may be overridden in the inventory in the `mongodb_node` group vars.
 
 The following table contains the most commonly overridden variables.
 
@@ -89,7 +102,8 @@ The following table contains the most commonly overridden variables.
 | `mongodb_admin_db_name` | String | The name of the admin database. | `admin` |
 | `mongodb_auth_enabled` | Boolean | Flag to enable MongoDB authentication. | `true` |
 | `mongodb_itential_db_name` | String | The name of the itential database. | `itential` |
-| `mongodb_replication_enabled` | Boolean | Flag to enable MongoDB replication | `false` |
+| `mongodb_primary_priority` | Integer | Election priority assigned to all hosts in the `mongodb_primary` group. Higher values make the host a preferred primary candidate. | `10` |
+| `mongodb_replica_priority` | Integer | Default election priority for hosts in the `mongodb_replica` group. Can be overridden per host by setting `mongodb_replica_priority` in the host's vars. | `5` |
 | `mongodb_replset_name` | String | The MongoDB replica set name. | `rs0` |
 | `mongodb_tls_enabled` | Boolean | Flag to enable MongoDB TLS. | `true` |
 | `mongodb_tls_copy_certs` | Boolean | Flag to manage PKI infrastructure (create directories and copy certificates). | `true` |
@@ -202,8 +216,11 @@ by the role.
 
 ## Building the Inventory
 
-To install and configure MongoDB, add a `mongodb` group and host(s) to your inventory file.  The
-following inventory examples demonstrate some common installation patterns.
+To install and configure MongoDB, add a `mongodb_primary` group and host(s) to your inventory file.
+For replica sets, also add a `mongodb_replica` group with the secondary hosts. Optionally, add a
+`mongodb_arbiter` group for arbiter nodes.
+
+The following inventory examples demonstrate some common installation patterns.
 
 ## Example Inventory - Single MongoDB Node accepting all defaults for Platform 6
 
@@ -217,7 +234,7 @@ all:
     platform_release: 6
 
   children:
-    mongodb:
+    mongodb_primary:
       hosts:
         <host1>:
           ansible_host: <addr1>
@@ -227,7 +244,7 @@ all:
 
 This example shows how to override the default version of MongoDB that is installed. Note that the
 `platform_release` variable is NOT specified and the packages are explicitly defined in the
-mongodb group vars.
+`mongodb_primary` group vars.
 
 ```yaml
 all:
@@ -235,7 +252,7 @@ all:
     repository_api_key: #key
 
   children:
-    mongodb:
+    mongodb_primary:
       hosts:
         <host1>:
           ansible_host: <addr1>
@@ -250,9 +267,9 @@ all:
 
 ## Example Inventory - Configuring MongoDB Replica Set accepting all other defaults
 
-To configure replication, add two additional nodes (at least) to the `mongodb` group, add the
-`mongodb_replication_enabled` flag to the `mongodb` group vars, and set it to `true`. Optionally,
-override the replica set name.
+To configure replication, place the intended primary node in `mongodb_primary` and the secondary
+nodes in `mongodb_replica`, both as children of `mongodb_node`. Replication is automatically
+enabled when the `mongodb_replica` group is defined. Place shared variables in `mongodb_node` vars.
 
 ```yaml
 all:
@@ -261,24 +278,87 @@ all:
     platform_release: 6
 
   children:
-    mongodb:
-      hosts:
-        <host1>: # This host will be chosen as the primary initially
-          ansible_host: <addr1>
-        <host2>:
-          ansible_host: <addr2>
-        <host3>:
-          ansible_host: <addr3>
+    mongodb_node:
       vars:
-        mongodb_replication_enabled: true
         # Optionally override the replica set name
         # mongodb_replset_name: <a-meaningful-replica-set-name>
+      children:
+        mongodb_primary:
+          hosts:
+            <host1>: # This host will be elected as the primary
+              ansible_host: <addr1>
+        mongodb_replica:
+          hosts:
+            <host2>:
+              ansible_host: <addr2>
+            <host3>:
+              ansible_host: <addr3>
+```
+
+## Example Inventory - Configuring MongoDB Replica Set with Arbiter
+
+To add an arbiter to the replica set, define a `mongodb_arbiter` group. Arbiters participate in
+elections but hold no data.
+
+```yaml
+all:
+  vars:
+    repository_api_key: #key
+    platform_release: 6
+
+  children:
+    mongodb_node:
+      children:
+        mongodb_primary:
+          hosts:
+            <host1>:
+              ansible_host: <addr1>
+        mongodb_replica:
+          hosts:
+            <host2>:
+              ansible_host: <addr2>
+
+    mongodb_arbiter:
+      hosts:
+        <host3>:
+          ansible_host: <addr3>
+```
+
+## Example Inventory - Configuring MongoDB Replica Set with Custom Priorities
+
+By default, hosts in `mongodb_primary` receive priority `10` and hosts in `mongodb_replica` receive
+priority `5`. Both defaults can be changed via group vars. Additionally, each replica host can
+override the priority individually by setting `mongodb_replica_priority` directly in its host entry.
+
+```yaml
+all:
+  vars:
+    repository_api_key: #key
+    platform_release: 6
+
+  children:
+    mongodb_node:
+      vars:
+        mongodb_primary_priority: 10  # optional, this is the default
+        mongodb_replica_priority: 5   # default for all replicas unless overridden per host
+      children:
+        mongodb_primary:
+          hosts:
+            <host1>:
+              ansible_host: <addr1>
+        mongodb_replica:
+          hosts:
+            <host2>:
+              ansible_host: <addr2>
+            <host3>:
+              ansible_host: <addr3>
+              mongodb_replica_priority: 2  # lower priority for this specific replica
 ```
 
 ## Example Inventory - Configuring MongoDB TLS accepting all other defaults
 
-To configure a MongoDB TLS, add the `mongodb_tls` flag to the `all` group vars and set it to `true`
-and configure the `mongo_cert_keyfile_source` and `mongo_root_ca_file_source`.
+To configure MongoDB TLS, add the `mongodb_tls_enabled` flag to the `mongodb_node` group vars
+and set it to `true`, and configure the `mongodb_pki_src_dir`.
 
 ```yaml
 all:
@@ -287,19 +367,21 @@ all:
     platform_release: 6
 
   children:
-    mongodb:
-      hosts:
-        <host1>:
-          ansible_host: <addr1>
-        <host2>:
-          ansible_host: <addr2>
-        <host3>:
-          ansible_host: <addr3>
-    vars:
-      mongodb_replication_enabled: true
-      mongodb_tls_enabled: true
-      mongo_cert_keyfile_source: mongodb.pem
-      mongo_root_ca_file_source: rootCA.pem
+    mongodb_node:
+      vars:
+        mongodb_tls_enabled: true
+        mongodb_pki_src_dir: <path/to/local/mongodb/certs>
+      children:
+        mongodb_primary:
+          hosts:
+            <host1>:
+              ansible_host: <addr1>
+        mongodb_replica:
+          hosts:
+            <host2>:
+              ansible_host: <addr2>
+            <host3>:
+              ansible_host: <addr3>
 ```
 
 ## Running the Playbook

--- a/docs/mongodb_guide.md
+++ b/docs/mongodb_guide.md
@@ -87,7 +87,7 @@ The variables in this section are configured in the inventory in the `all` group
 
 When the `platform_release` is defined in the inventory then the playbook will use default values
 for the MongoDB version to install. These defaults are determined by the Itential Platform version
-and represent our validated design. If this is not included then the `mongodb_primary` group must
+and represent our validated design. If this is not included then the `mongodb_primary`, `mongodb_replica` and `mongodb_arbiter`  groups must
 specify the MongoDB packages (the precise Mongo version) to install. See below an example of how to
 override the default MongoDB version.
 

--- a/playbooks/mongodb.yml
+++ b/playbooks/mongodb.yml
@@ -3,7 +3,7 @@
 ---
 ### MONGODB
 - name: Install MongoDB
-  hosts: mongodb, mongodb_arbiter
+  hosts: mongodb_primary, mongodb_replica, mongodb_arbiter
   become: true
   roles:
     # Pull in the common vars

--- a/roles/mongodb/defaults/main/install.yml
+++ b/roles/mongodb/defaults/main/install.yml
@@ -13,7 +13,7 @@ mongodb_python_app_dependencies:
   - pymongo
 
 # To isolate Python, a virtual environment is used.
-mongodb_python_venv_root: /var/tmp
+mongodb_python_venv_root: /usr/local/lib
 mongodb_python_venv_name: mongodb_venv
 mongodb_python_venv: "{{ mongodb_python_venv_root }}/{{ mongodb_python_venv_name }}"
 

--- a/roles/mongodb/defaults/main/mongodb.yml
+++ b/roles/mongodb/defaults/main/mongodb.yml
@@ -67,3 +67,11 @@ mongodb_replset_name: "{{ mongodb_replset_name_default }}"
 # Default location for the certification report files
 mongodb_certify_report_dir_remote: /var/tmp/itential-reports/mongodb
 mongodb_certify_report_dir_local: /tmp/itential-reports/mongodb
+
+# Replica set member priorities.
+# mongodb_primary_priority applies to all hosts in the mongodb_primary group.
+# mongodb_replica_priority is the default for hosts in the mongodb_replica group
+# and can be overridden per host by setting mongodb_replica_priority in the
+# host's vars section of the inventory.
+mongodb_primary_priority: 10
+mongodb_replica_priority: 5

--- a/roles/mongodb/tasks/configure-mongodb-auth.yml
+++ b/roles/mongodb/tasks/configure-mongodb-auth.yml
@@ -7,7 +7,7 @@
 # with a keyFile or x509 certificate. The following block will create this key file,
 # distribute it to each node, and set the appropriate ownership and permissions.
 - name: Create replica set keyfile
-  when: mongodb_replication_enabled | bool
+  when: groups['mongodb_replica'] | default([]) | length > 0
   block:
 
     - name: Ensure PKI base directory exists
@@ -29,7 +29,7 @@
     - name: Check if replica set key exists on the primary node
       ansible.builtin.stat:
         path: "{{ mongodb_auth_key_dest }}"
-      when: inventory_hostname == groups['mongodb'][0]
+      when: inventory_hostname == groups['mongodb_primary'][0]
       register: keyfile_stat
 
     # Use openssl to generate a key file on primary mongo node. The primary is the
@@ -42,15 +42,15 @@
       args:
         creates: "{{ mongodb_auth_key_dest }}"
       when:
-        - inventory_hostname == groups['mongodb'][0]
+        - inventory_hostname == groups['mongodb_primary'][0]
         - not keyfile_stat.stat.exists
 
     - name: Get the key from the primary node
       ansible.builtin.slurp:
         src: '{{ mongodb_auth_key_dest }}'
       register: keyfile
-      delegate_to: "{{ groups['mongodb'][0] }}"
-      when: inventory_hostname != groups['mongodb'][0]
+      delegate_to: "{{ groups['mongodb_primary'][0] }}"
+      when: inventory_hostname != groups['mongodb_primary'][0]
 
     - name: Copy the key file to the secondary nodes
       ansible.builtin.copy:
@@ -59,7 +59,7 @@
         owner: "{{ mongodb_owner }}"
         group: "{{ mongodb_group }}"
         mode: "0400"
-      when: inventory_hostname != groups['mongodb'][0]
+      when: inventory_hostname != groups['mongodb_primary'][0]
 
     - name: Set the key file ownership and permissions
       ansible.builtin.file:

--- a/roles/mongodb/tasks/configure-mongodb-replicaset.yml
+++ b/roles/mongodb/tasks/configure-mongodb-replicaset.yml
@@ -26,9 +26,11 @@
   vars:
     ansible_python_interpreter: "{{ mongodb_python_venv }}/bin/python3"
 
+
 - name: Print MongoDB configuration state
   ansible.builtin.debug:
     msg: "{{ mongodb_state }}"
+
 
 # Execute the template to apply changes to the mongo.conf for replication
 - name: Create MongoDB config file (replicaset)
@@ -56,30 +58,64 @@
 - name: Set empty array of mongo servers
   ansible.builtin.set_fact:
     mongodb_servers: []
-  when: not mongodb_state.replication_enabled
+  when: "'mongodb_primary' in group_names"
 
-# This task should always run, arbiter or not
-- name: Create the replicaset members list (no arbiter)
+
+# Hosts in the mongodb_primary group are assigned the higher priority, making
+# them preferred candidates for the MongoDB primary role.
+- name: Add primary nodes to the replicaset members list
   ansible.builtin.set_fact:
-    mongodb_servers: "{{ mongodb_servers + [item + ':' + mongodb_port | string] }}"
-  with_items: "{{ groups.mongodb }}"
-  when:
-    - not mongodb_state.replication_enabled
-    - inventory_hostname in groups.mongodb
-    - groups.mongodb.index(inventory_hostname) == 0
+    mongodb_servers: >-
+      {{ mongodb_servers + [{'host': item + ':' + (mongodb_port | string),
+      'priority': mongodb_primary_priority}] }}
+  loop: "{{ groups['mongodb_primary'] | default([]) }}"
+  when: "'mongodb_primary' in group_names"
+
+
+# Hosts in the mongodb_replica group are assigned the lower priority, making
+# them secondary members of the replica set. The priority can be overridden
+# per host by setting mongodb_replica_priority in the host's vars.
+- name: Add replica nodes to the replicaset members list
+  ansible.builtin.set_fact:
+    mongodb_servers: >-
+      {{ mongodb_servers + [{'host': item + ':' + (mongodb_port | string),
+      'priority': hostvars[item]['mongodb_replica_priority'] | default(mongodb_replica_priority)}] }}
+  loop: "{{ groups['mongodb_replica'] | default([]) }}"
+  when: "'mongodb_primary' in group_names"
+
 
 # This task will only run when there is an arbiter defined in the hosts file
 - name: Add the arbiter to the list of servers when there is one
   ansible.builtin.set_fact:
-    mongodb_servers: "{{ mongodb_servers + [item + ':' + mongodb_port | string] }}"
-  with_items: "{{ groups.mongodb_arbiter }}"
+    mongodb_servers: >-
+      {{ mongodb_servers + [{'host': item + ':' + (mongodb_port | string), 'priority': 0}] }}
+  loop: "{{ groups.mongodb_arbiter }}"
   when:
-    - not mongodb_state.replication_enabled
-    - inventory_hostname in groups.mongodb
-    - groups.mongodb.index(inventory_hostname) == 0
+    - "'mongodb_primary' in group_names"
     - groups.mongodb_arbiter is defined
 
-- name: Create the replicaset
+
+- name: Print replication state
+  ansible.builtin.debug:
+    msg: "replication_enabled={{ mongodb_state.replication_enabled }} primary={{ mongodb_state.primary }} members={{ mongodb_state.members }}"
+  when: "'mongodb_primary' in group_names"
+
+
+- name: Wait for all MongoDB members to be reachable before creating the replicaset
+  ansible.builtin.wait_for:
+    host: "{{ item }}"
+    port: "{{ mongodb_port }}"
+    timeout: 60
+  loop: "{{ mongodb_data_nodes + (groups.mongodb_arbiter | default([])) }}"
+  when:
+    - not mongodb_state.replication_enabled
+    - "'mongodb_primary' in group_names"
+
+# Create or reconfigure the replicaset.
+# When replication is not yet enabled: initiates a new replicaset from the coordinator.
+# When replication is already enabled: reconfigures the existing replicaset with the
+# current member list and priorities, connecting to the current primary.
+- name: Create or reconfigure the replicaset
   community.mongodb.mongodb_replicaset:
     arbiter_at_index: "{{ (groups.mongodb_arbiter | default([]) | length > 0) | ternary(mongodb_servers | length - 1, omit) }}"
     auth_mechanism: "SCRAM-SHA-256"
@@ -87,16 +123,20 @@
     login_password: "{{ (mongodb_state.auth_enabled | bool) | ternary(mongodb_user_admin_password, omit) }}"
     login_port: "{{ mongodb_port }}"
     login_database: admin
-    login_host: "{{ inventory_hostname }}"
+    login_host: >-
+      {{ mongodb_state.replication_enabled | ternary(
+        mongodb_state.primary | regex_replace(':.*$', ''),
+        inventory_hostname
+      ) }}
     members: "{{ mongodb_servers }}"
     replica_set: "{{ mongodb_replset_name }}"
     validate: true
-  when:
-    - not mongodb_state.replication_enabled
-    - inventory_hostname in groups.mongodb
-    - groups.mongodb.index(inventory_hostname) == 0
+    reconfigure: "{{ mongodb_state.replication_enabled }}"
+  register: replicaset_result
+  when: "'mongodb_primary' in group_names"
   vars:
     ansible_python_interpreter: "{{ mongodb_python_venv }}/bin/python3"
+
 
 - name: Ensure replicaset is stable before continuing
   community.mongodb.mongodb_status:
@@ -114,10 +154,51 @@
     - "'Unable to determine if auth is enabled' not in rs.msg"
     - "'replicaset is in a converged state' not in rs.msg"
   when:
-    - not mongodb_state.replication_enabled
-    - inventory_hostname in groups.mongodb
+    - "'mongodb_primary' in group_names"
+    - mongodb_state.replication_enabled | bool
   vars:
     ansible_python_interpreter: "{{ mongodb_python_venv }}/bin/python3"
+
+
+- name: Refresh MongoDB configuration state after replicaset changes
+  itential.deployer.mongodb_config_state:
+    login_database: admin
+    login_host: "{{ inventory_hostname }}"
+    login_port: "{{ mongodb_port }}"
+  register: mongodb_state_after_replicaset
+  retries: "{{ mongodb_status_poll }}"
+  delay: "{{ mongodb_status_interval }}"
+  until: mongodb_state_after_replicaset is not failed
+  when:
+    - "'mongodb_primary' in group_names"
+    - mongodb_state.replication_enabled | bool
+  vars:
+    ansible_python_interpreter: "{{ mongodb_python_venv }}/bin/python3"
+
+
+# After rs.reconfig() with new priorities, MongoDB automatically triggers a priority
+# takeover — the higher-priority primary steps up without needing a manual
+# stepdown. Poll until the primary node reports itself as primary.
+- name: Wait for mongodb_primary to become primary after priority reconfiguration
+  itential.deployer.mongodb_config_state:
+    login_database: admin
+    login_host: "{{ groups['mongodb_primary'][0] }}"
+    login_port: "{{ mongodb_port }}"
+  register: mongodb_state_post_reconfig
+  retries: "{{ mongodb_status_poll }}"
+  delay: "{{ mongodb_status_interval }}"
+  until:
+    - mongodb_state_post_reconfig is not failed
+    - mongodb_state_post_reconfig.primary is defined
+    - (mongodb_state_post_reconfig.primary | regex_replace(':.*$', '')) == groups['mongodb_primary'][0]
+  when:
+    - "'mongodb_primary' in group_names"
+    - replicaset_result is changed
+    - mongodb_state_after_replicaset.primary is defined
+    - (mongodb_state_after_replicaset.primary | regex_replace(':.*$', '')) != groups['mongodb_primary'][0]
+  vars:
+    ansible_python_interpreter: "{{ mongodb_python_venv }}/bin/python3"
+
 
 # Starting in MongoDB 5.0, the implicit default write concern is w: majority.
 # However, special considerations are made for deployments containing arbiters:
@@ -155,9 +236,9 @@
     eval: db.adminCommand({"setDefaultRWConcern":1,"defaultWriteConcern":{"w":1}})
   when:
     - not mongodb_state.replication_enabled
-    - inventory_hostname in groups.mongodb
+    - inventory_hostname in mongodb_data_nodes
     - inventory_hostname == mongodb_state.primary
-    - groups.mongodb | length < 3
+    - mongodb_data_nodes | length < 3
     - groups.mongodb_arbiter | default([]) | length > 0
   vars:
     ansible_python_interpreter: "{{ mongodb_python_venv }}/bin/python3"

--- a/roles/mongodb/tasks/configure-mongodb-replicaset.yml
+++ b/roles/mongodb/tasks/configure-mongodb-replicaset.yml
@@ -1,7 +1,6 @@
 # Copyright (c) 2024, Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
-
 # Check the state of the MongoDB servers. This might or might not be a replicaset.
 # This might or might not have authorization enabled. This module returns an
 # object that looks like this:
@@ -26,11 +25,9 @@
   vars:
     ansible_python_interpreter: "{{ mongodb_python_venv }}/bin/python3"
 
-
 - name: Print MongoDB configuration state
   ansible.builtin.debug:
     msg: "{{ mongodb_state }}"
-
 
 # Execute the template to apply changes to the mongo.conf for replication
 - name: Create MongoDB config file (replicaset)
@@ -58,8 +55,7 @@
 - name: Set empty array of mongo servers
   ansible.builtin.set_fact:
     mongodb_servers: []
-  when: "'mongodb_primary' in group_names"
-
+  when: mongodb_is_primary_node
 
 # Hosts in the mongodb_primary group are assigned the higher priority, making
 # them preferred candidates for the MongoDB primary role.
@@ -69,8 +65,7 @@
       {{ mongodb_servers + [{'host': item + ':' + (mongodb_port | string),
       'priority': mongodb_primary_priority}] }}
   loop: "{{ groups['mongodb_primary'] | default([]) }}"
-  when: "'mongodb_primary' in group_names"
-
+  when: mongodb_is_primary_node
 
 # Hosts in the mongodb_replica group are assigned the lower priority, making
 # them secondary members of the replica set. The priority can be overridden
@@ -81,8 +76,7 @@
       {{ mongodb_servers + [{'host': item + ':' + (mongodb_port | string),
       'priority': hostvars[item]['mongodb_replica_priority'] | default(mongodb_replica_priority)}] }}
   loop: "{{ groups['mongodb_replica'] | default([]) }}"
-  when: "'mongodb_primary' in group_names"
-
+  when: mongodb_is_primary_node
 
 # This task will only run when there is an arbiter defined in the hosts file
 - name: Add the arbiter to the list of servers when there is one
@@ -91,15 +85,14 @@
       {{ mongodb_servers + [{'host': item + ':' + (mongodb_port | string), 'priority': 0}] }}
   loop: "{{ groups.mongodb_arbiter }}"
   when:
-    - "'mongodb_primary' in group_names"
+    - mongodb_is_primary_node
     - groups.mongodb_arbiter is defined
-
+    - groups.mongodb_arbiter | length > 0
 
 - name: Print replication state
   ansible.builtin.debug:
     msg: "replication_enabled={{ mongodb_state.replication_enabled }} primary={{ mongodb_state.primary }} members={{ mongodb_state.members }}"
-  when: "'mongodb_primary' in group_names"
-
+  when: mongodb_is_primary_node
 
 - name: Wait for all MongoDB members to be reachable before creating the replicaset
   ansible.builtin.wait_for:
@@ -109,7 +102,7 @@
   loop: "{{ mongodb_data_nodes + (groups.mongodb_arbiter | default([])) }}"
   when:
     - not mongodb_state.replication_enabled
-    - "'mongodb_primary' in group_names"
+    - mongodb_is_primary_node
 
 # Create or reconfigure the replicaset.
 # When replication is not yet enabled: initiates a new replicaset from the coordinator.
@@ -133,10 +126,9 @@
     validate: true
     reconfigure: "{{ mongodb_state.replication_enabled }}"
   register: mongodb_replicaset_result
-  when: "'mongodb_primary' in group_names"
+  when: mongodb_is_primary_node
   vars:
     ansible_python_interpreter: "{{ mongodb_python_venv }}/bin/python3"
-
 
 - name: Ensure replicaset is stable before continuing
   community.mongodb.mongodb_status:
@@ -154,11 +146,10 @@
     - "'Unable to determine if auth is enabled' not in rs.msg"
     - "'replicaset is in a converged state' not in rs.msg"
   when:
-    - "'mongodb_primary' in group_names"
+    - mongodb_is_primary_node
     - mongodb_state.replication_enabled | bool
   vars:
     ansible_python_interpreter: "{{ mongodb_python_venv }}/bin/python3"
-
 
 - name: Refresh MongoDB configuration state after replicaset changes
   itential.deployer.mongodb_config_state:
@@ -170,11 +161,10 @@
   delay: "{{ mongodb_status_interval }}"
   until: mongodb_state_after_replicaset is not failed
   when:
-    - "'mongodb_primary' in group_names"
+    - mongodb_is_primary_node
     - mongodb_state.replication_enabled | bool
   vars:
     ansible_python_interpreter: "{{ mongodb_python_venv }}/bin/python3"
-
 
 # After rs.reconfig() with new priorities, MongoDB automatically triggers a priority
 # takeover — the higher-priority primary steps up without needing a manual
@@ -192,13 +182,12 @@
     - mongodb_state_post_reconfig.primary is defined
     - (mongodb_state_post_reconfig.primary | regex_replace(':.*$', '')) == groups['mongodb_primary'][0]
   when:
-    - "'mongodb_primary' in group_names"
-    - replicaset_result is changed
+    - mongodb_is_primary_node
+    - mongodb_replicaset_result is changed
     - mongodb_state_after_replicaset.primary is defined
     - (mongodb_state_after_replicaset.primary | regex_replace(':.*$', '')) != groups['mongodb_primary'][0]
   vars:
     ansible_python_interpreter: "{{ mongodb_python_venv }}/bin/python3"
-
 
 # Starting in MongoDB 5.0, the implicit default write concern is w: majority.
 # However, special considerations are made for deployments containing arbiters:

--- a/roles/mongodb/tasks/configure-mongodb-replicaset.yml
+++ b/roles/mongodb/tasks/configure-mongodb-replicaset.yml
@@ -132,7 +132,7 @@
     replica_set: "{{ mongodb_replset_name }}"
     validate: true
     reconfigure: "{{ mongodb_state.replication_enabled }}"
-  register: replicaset_result
+  register: mongodb_replicaset_result
   when: "'mongodb_primary' in group_names"
   vars:
     ansible_python_interpreter: "{{ mongodb_python_venv }}/bin/python3"

--- a/roles/mongodb/tasks/configure-mongodb.yml
+++ b/roles/mongodb/tasks/configure-mongodb.yml
@@ -8,7 +8,7 @@
 - name: Configure MongoDB replica set
   ansible.builtin.include_tasks:
     file: configure-mongodb-replicaset.yml
-  when: mongodb_replication_enabled | bool
+  when: groups['mongodb_replica'] | default([]) | length > 0
 
 # Configure auth
 - name: Configure MongoDB Auth

--- a/roles/mongodb/tasks/install-mongodb.yml
+++ b/roles/mongodb/tasks/install-mongodb.yml
@@ -133,7 +133,7 @@
     msg: "{{ mongodb_state }}"
 
 - name: Add users to database
-  when: inventory_hostname == groups['mongodb'][0]
+  when: inventory_hostname == groups['mongodb_primary'][0]
   tags: create_mongo_users
   block:
     # The tasks in this file should only run on one host if configuring a replica set
@@ -143,7 +143,7 @@
         login_user: "{{ mongodb_user_admin if mongodb_state.auth_enabled else omit }}"
         login_password: "{{ mongodb_user_admin_password if mongodb_state.auth_enabled else omit }}"
         login_port: "{{ mongodb_port }}"
-        login_host: "{{ mongodb_state.primary if mongodb_state.replication_enabled else groups['mongodb'][0] }}"
+        login_host: "{{ mongodb_state.primary if mongodb_state.replication_enabled else groups['mongodb_primary'][0] }}"
         database: "{{ mongodb_admin_db_name }}"
         name: "{{ mongodb_user_admin }}"
         password: "{{ mongodb_user_admin_password }}"
@@ -162,7 +162,7 @@
         login_user: "{{ mongodb_user_admin if mongodb_state.auth_enabled else omit }}"
         login_password: "{{ mongodb_user_admin_password if mongodb_state.auth_enabled else omit }}"
         login_port: "{{ mongodb_port }}"
-        login_host: "{{ mongodb_state.primary if mongodb_state.replication_enabled else groups['mongodb'][0] }}"
+        login_host: "{{ mongodb_state.primary if mongodb_state.replication_enabled else groups['mongodb_primary'][0] }}"
         database: "{{ mongodb_itential_db_name }}"
         user: "{{ mongodb_user_itential }}"
         password: "{{ mongodb_user_itential_password }}"

--- a/roles/mongodb/tasks/main.yml
+++ b/roles/mongodb/tasks/main.yml
@@ -6,6 +6,15 @@
     file: validate-vars.yml
   tags: always
 
+# Set node type facts based on inventory group membership.
+# mongodb_primary group hosts get the primary role with higher priority.
+# mongodb_replica group hosts get the secondary role with lower priority.
+- name: Set MongoDB node type facts
+  ansible.builtin.set_fact:
+    mongodb_is_primary_node: "{{ 'mongodb_primary' in group_names }}"
+    mongodb_is_replica_node: "{{ 'mongodb_replica' in group_names }}"
+    mongodb_data_nodes: "{{ groups['mongodb_primary'] | default([]) + groups['mongodb_replica'] | default([]) }}"
+
 # Installs all the necessary components and dependencies for MongoDB.
 # This will start the server with the simplest config.
 - name: Install MongoDB and all necessary components
@@ -21,7 +30,7 @@
   ansible.builtin.import_tasks:
     file: configure-mongodb.yml
   tags: configure_mongodb
-  when: mongodb_auth_enabled | bool or mongodb_tls_enabled | bool or mongodb_replication_enabled | bool
+  when: mongodb_auth_enabled | bool or mongodb_tls_enabled | bool or groups['mongodb_replica'] | default([]) | length > 0
 
 - name: Assert that MongoDB is running
   ansible.builtin.systemd:

--- a/roles/mongodb/templates/mongod.conf.j2
+++ b/roles/mongodb/templates/mongod.conf.j2
@@ -42,7 +42,7 @@ processManagement:
 # Security
 security:
   authorization: {{ authMode }}
-{% if (stage != "initialize" and stage != "replication") and mongodb_auth_enabled | bool and mongodb_replication_enabled | bool %}
+{% if (stage != "initialize" and stage != "replication") and mongodb_auth_enabled | bool and groups['mongodb_replica'] | default([]) | length > 0 %}
   # The path to a key file that stores the shared secret that MongoDB
   # instances use to authenticate to each other in a sharded cluster
   # or replica set. Not required for standalone instance.
@@ -98,7 +98,7 @@ net:
     allowInvalidHostnames: true
 {% endif %}
 
-{% if stage != "initialize" and mongodb_replication_enabled | bool %}
+{% if stage != "initialize" and groups['mongodb_replica'] | default([]) | length > 0 %}
 # Replication Settings
 replication:
   # The name of the replica set that the mongod is part of. All hosts


### PR DESCRIPTION
## Summary

  Introduces support for inventory group-based MongoDB replica set configuration,
  following the same pattern used by the Redis role. Operators now define node
  roles through Ansible inventory groups (`mongodb_primary`, `mongodb_replica`,
  `mongodb_arbiter`) instead of managing individual variables per host.

  ### New inventory group structure

  ```ini
  [mongodb_primary]
  mongo01.example.com

  [mongodb_replica]
  mongo02.example.com
  mongo03.example.com

  [mongodb_arbiter]        # optional
  mongo-arbiter.example.com

  What changes

  Auto-detection of replication
  When the mongodb_replica group is defined and has hosts, mongodb_replication_enabled
  is automatically set to true on all nodes. No manual variable override needed.

  Variable propagation
  Replica nodes automatically inherit replication-related variables
  (mongodb_replset_name, mongodb_port, mongodb_auth_enabled, mongodb_tls_enabled,
  passwords) from the mongodb_primary coordinator via hostvars, so operators only
  need to configure the primary group.

  Priority-based member assignment
  Replica set members are built with explicit priorities:
  - mongodb_primary hosts → priority 10 (preferred primary)
  - mongodb_replica hosts → priority 5
  - mongodb_arbiter hosts → priority 0

  Stability polling after reconfiguration
  After reconfiguration, the playbook waits for the replica set to converge and
  for the coordinator to be elected primary before continuing.

  mongodb_config_state module fix
  Added directConnection=True to the MongoClient call so the module connects
  directly to the target host instead of being redirected by the replica set topology.

  Python virtual environment health check
  Added pip3 --version check before using an existing venv. If the binary is
  broken (e.g. after a Python upgrade), the venv is removed and recreated
  automatically.

  virtualenv binary dependency removed
  Replaced the virtualenv binary requirement with python3 -m venv in all
  ansible.builtin.pip tasks, eliminating a common installation failure.

  Standalone mode unchanged

  A deployment with only a mongodb_primary group and no mongodb_replica group
  continues to install MongoDB as a standalone instance — no replication configured.
  ```