### PR TITLE
Add CLAUDE.md documentation for collection root and all roles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,157 @@
+# itential.deployer — Ansible Collection
+
+## Overview
+
+`itential.deployer` is an Ansible collection (namespace: `itential`, version: `3.7.2`) that deploys the full Itential automation platform stack: Itential Platform (IAP), Itential Automation Gateway (IAG), MongoDB, and Redis. It supports online and offline (air-gapped) installations, TLS configuration, and multiple deployment topologies.
+
+## Collection Metadata
+
+| Field | Value |
+|-------|-------|
+| Namespace | `itential` |
+| Name | `deployer` |
+| Version | `3.7.2` |
+| Min ansible-core | `>=2.11, <2.17` |
+| Min Python | `>=3.9` |
+
+## Dependencies
+
+| Collection | Version Constraint |
+|------------|-------------------|
+| `ansible.posix` | `>=0.0.1` |
+| `community.general` | `<12.0.0` |
+| `community.mongodb` | `>=0.0.1` |
+
+Also requires the `jmespath` Python module on the control node.
+
+## Playbook Inventory
+
+| Playbook | FQCN | Description |
+|----------|------|-------------|
+| `site.yml` | `itential.deployer.site` | Full stack install: Redis + MongoDB + Platform + Gateway |
+| `platform_site.yml` | `itential.deployer.platform_site` | Platform stack only: Redis + MongoDB + Platform |
+| `install.yml` | `itential.deployer.install` | Alias for `site.yml` |
+| `platform.yml` | `itential.deployer.platform` | Install Itential Platform on `platform`/`platform_secondary` hosts |
+| `gateway.yml` | `itential.deployer.gateway` | Install IAG on `gateway` hosts |
+| `mongodb.yml` | `itential.deployer.mongodb` | Install MongoDB on `mongodb_primary`, `mongodb_replica`, `mongodb_arbiter` hosts |
+| `redis.yml` | `itential.deployer.redis` | Install Redis on `redis_master`/`redis_replica`; Sentinel on `redis_sentinel` hosts |
+| `os.yml` | `itential.deployer.os` | Install base OS packages on all component hosts |
+| `nginx.yml` | `itential.deployer.nginx` | Install and configure nginx (wraps `nginxinc.nginx` and `nginxinc.nginx_config`) |
+| `nginx_install.yml` | `itential.deployer.nginx_install` | Install nginx only |
+| `nginx_configure.yml` | `itential.deployer.nginx_configure` | Configure nginx, SELinux booleans, firewalld port, restart |
+| `patch_platform.yml` | `itential.deployer.patch_platform` | Upgrade Itential Platform in-place |
+| `patch_gateway.yml` | `itential.deployer.patch_gateway` | Upgrade IAG in-place |
+| `certify.yml` | `itential.deployer.certify` | Run all certification playbooks (Redis + MongoDB + Platform) |
+| `certify_redis.yml` | `itential.deployer.certify_redis` | Generate Redis/Sentinel installation certification reports |
+| `certify_mongodb.yml` | `itential.deployer.certify_mongodb` | Generate MongoDB installation certification reports |
+| `certify_platform.yml` | `itential.deployer.certify_platform` | Generate Platform installation certification reports |
+| `verify.yml` | `itential.deployer.verify` | Pre-install environment verification (OS, HW specs, proxy) for all components |
+| `verify_redis.yml` | `itential.deployer.verify_redis` | Pre-install verification for Redis hosts |
+| `verify_mongodb.yml` | `itential.deployer.verify_mongodb` | Pre-install verification for MongoDB hosts |
+| `verify_platform.yml` | `itential.deployer.verify_platform` | Pre-install verification for Platform hosts |
+| `download_packages_site.yml` | `itential.deployer.download_packages_site` | Download all packages for offline install (Platform stack + Gateway) |
+| `download_packages_platform_site.yml` | `itential.deployer.download_packages_platform_site` | Download all packages for Platform stack offline install |
+| `download_packages_platform.yml` | `itential.deployer.download_packages_platform` | Download Platform packages for offline install |
+| `download_packages_gateway.yml` | `itential.deployer.download_packages_gateway` | Download Gateway packages for offline install |
+| `download_packages_gateway_site.yml` | `itential.deployer.download_packages_gateway_site` | Wraps `download_packages_gateway` with a tag |
+| `download_packages_mongodb.yml` | `itential.deployer.download_packages_mongodb` | Download MongoDB packages for offline install |
+| `download_packages_redis.yml` | `itential.deployer.download_packages_redis` | Download Redis packages for offline install |
+| `download_packages_os.yml` | `itential.deployer.download_packages_os` | Download OS packages for offline install |
+
+## Inventory Topology Options
+
+| Topology | Directory | Description |
+|----------|-----------|-------------|
+| `aio` | `example_inventories/aio/` | All-in-one: all components on a single host. For dev/CI use. TLS off by default. |
+| `minimal` | `example_inventories/minimal/` | Single instance of each component on separate hosts. Exercises network paths. TLS configurable. |
+| `ha2` | `example_inventories/ha2/` | High-availability: 2 Platform nodes, 3-node MongoDB replica set, 3-node Redis+Sentinel cluster, 1 Gateway. Recommended for test and production. |
+| `asa` | `example_inventories/asa/` | Active/Standby: 5-node MongoDB (4 data + 1 arbiter across 3 DCs), 4-node Redis across 3 DCs. Disaster recovery topology. |
+| `platform` | `example_inventories/platform/` | Platform-only example showing external (managed) Redis/MongoDB via URL. |
+| `redis` | `example_inventories/redis/` | Redis-only examples: install from Remi repo, from system repo, or from source. |
+
+## Roles Summary
+
+| Role | Purpose |
+|------|---------|
+| `common` | Shared defaults (`offline_install_enabled`, `common_install_yum_repos`, release file path). No tasks in main. |
+| `os` | Installs base OS and security packages (RedHat family only). Skips if `itential-release` file exists. |
+| `python` | Shared utility role for installing Python packages and pip dependencies (no defaults of its own; callers pass vars). |
+| `selinux` | Shared utility role for compiling and installing custom SELinux `.te` policy modules from the calling role's `files/` directory. |
+| `offline` | Shared utility role for downloading and installing RPMs/wheels/adapters in air-gapped mode. |
+| `mongodb` | Installs and configures MongoDB: users, replica set, auth, TLS, kernel tuning, SELinux, logrotate, NUMA. |
+| `redis` | Installs and configures Redis (from source or repo) and Redis Sentinel: auth, TLS, replication, SELinux. |
+| `platform` | Installs and configures Itential Platform: NodeJS, Python, RPM packages, adapters, properties file, TLS certs, Vault, SELinux. |
+| `gateway` | Installs and configures Itential Automation Gateway (IAG): Python venv, Ansible, Nornir, TLS certs, systemd service, SELinux. |
+
+## Key Global Variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `platform_release` | (required) | Platform release version (e.g., `6`). Drives package/Python/NodeJS selection. |
+| `offline_install_enabled` | `false` | Enables air-gapped installation mode across all roles. |
+| `offline_target_node_root` | `/var/tmp` | Root directory on target nodes for offline packages. |
+| `offline_control_node_root` | `{{ playbook_dir }}/files` | Root directory on the control node where offline packages are staged. |
+| `offline_itential_packages_path` | `itential_packages/{{ distro }}_{{ major_ver }}` | Subdirectory within offline roots for per-OS package sets. |
+| `common_install_yum_repos` | `true` | When `false`, skips YUM repo installation (use internal repos instead). |
+| `common_itential_release_file` | `/etc/itential-release` | Path to the file tracking installed component versions. |
+| `env` | (required for verify) | Deployment environment (`dev`, `test`, `prod`). Used for hardware spec validation. |
+| `repository_username` | (optional) | Username for downloading packages from Nexus/JFrog. |
+| `repository_password` | (optional) | Password for downloading packages from Nexus/JFrog. |
+| `repository_api_key` | (optional) | API key for downloading packages from JFrog. |
+
+## TLS Overview
+
+TLS is supported at the component level and is **enabled by default** for MongoDB and Platform, and **disabled by default** for Redis.
+
+| Component | Enable Flag | Copy-Certs Flag | PKI Base Dir |
+|-----------|------------|-----------------|--------------|
+| MongoDB | `mongodb_tls_enabled: true` | `mongodb_tls_copy_certs: true` | `/etc/pki/mongodb` |
+| Redis | `redis_tls_enabled: false` | n/a (always copies when TLS enabled) | `/etc/pki/redis` |
+| Platform (HTTPS) | `platform_webserver_https_enabled: true` | `platform_webserver_https_copy_certs: true` | `/etc/pki/itential-platform/https` |
+| Platform (MongoDB client) | `platform_mongo_tls_enabled: true` | `platform_mongodb_copy_certs: true` | `/etc/pki/itential-platform/mongodb` |
+| Gateway (HTTPS) | `gateway_https_enabled: true` | `gateway_pki_copy_certs: true` | `/etc/pki/automation-gateway` |
+
+The deployer does **not** generate certificates. Certificates must be provided on the Ansible control node; the deployer copies them to targets. Each role uses a `*_pki_src_dir` variable pointing to the certificate source directory on the control node.
+
+## Offline Install
+
+When `offline_install_enabled: true`, the deployer skips all internet-facing package downloads and instead installs from a pre-staged local directory. The `download_packages_*` playbooks are used to stage packages while the target still has internet access (or from a machine that does). The offline directory layout is:
+
+```
+files/
+  itential_packages/
+    <distro>_<major_ver>/
+      <platform_release>/
+        platform/rpms/
+        platform/wheels/
+        platform/adapters/
+      <gateway_release>/
+        gateway/rpms/
+        gateway/wheels/
+        gateway/collections/
+```
+
+See `docs/offline_install_guide.md` for the full workflow.
+
+## Custom Plugins / Modules
+
+| Module | Purpose |
+|--------|---------|
+| `itential.deployer.gather_host_information` | Collects OS, architecture, and hardware facts used by the `verify-host.yml` task file. |
+| `itential.deployer.mongodb_config_state` | Queries a running MongoDB instance to determine whether auth and replication are already configured. Used to make user-creation tasks idempotent. |
+
+## Docs Index
+
+| File | Contents |
+|------|----------|
+| `docs/itential_platform_guide.md` | Platform role variables, adapters, Vault config, logging, webserver settings |
+| `docs/itential_gateway_guide.md` | Gateway role variables, feature flags, Ansible/Nornir config |
+| `docs/mongodb_guide.md` | MongoDB role variables, replica set, TLS, user accounts |
+| `docs/redis_guide.md` | Redis role variables, Sentinel, TLS, install methods |
+| `docs/tls_guide.md` | End-to-end TLS configuration guide across all components |
+| `docs/offline_install_guide.md` | Step-by-step offline (air-gapped) install workflow |
+| `docs/patch_itential_platform_guide.md` | How to run `patch_platform.yml` to upgrade Platform |
+| `docs/patch_itential_gateway_guide.md` | How to run `patch_gateway.yml` to upgrade IAG |
+| `docs/preflight_guide.md` | How to run the `verify` playbooks and interpret results |
+| `docs/nginx.md` | Nginx reverse-proxy setup and configuration |
+| `docs/release_notes_v4.md` | Release notes for v4 changes |

--- a/roles/common/CLAUDE.md
+++ b/roles/common/CLAUDE.md
@@ -1,0 +1,54 @@
+# Role: common
+
+## Purpose
+
+Provides shared default variables consumed by all other roles. Has no `main.yml` task entry point — it is imported by playbooks solely to inject its defaults into the variable scope. Also contains the shared `verify-host.yml` task file used by the `verify_*` playbooks.
+
+## Entry Point Tasks
+
+There is no `tasks/main.yml`. The only task file is:
+
+- `tasks/verify-host.yml` — imported by `verify_redis`, `verify_mongodb`, and `verify_platform` task files via `tasks_from:`. It is not called by any role's `main.yml`.
+
+## verify-host.yml Logic
+
+Expects two variables from the caller:
+
+| Variable | Example | Purpose |
+|----------|---------|---------|
+| `component_name` | `"Redis"` | Used in debug messages |
+| `hw_specs_var_name` | `"redis_hw_specs"` | Name of the hardware specs dict variable to validate against |
+
+Execution order:
+1. Assert `platform_release` and `env` are defined, `env` in `['dev','test','prod']`
+2. Call `itential.deployer.gather_host_information` module to collect OS/arch/hardware facts
+3. Validate OS: RedHat/Rocky/OracleLinux 8 or 9, or Amazon Linux 2023
+4. Validate architecture: `x86_64` or `aarch64`
+5. Validate CPU, RAM, and disk against the `hw_specs_var_name[env]` dict (uses `ignore_errors: true` and collects failures into `validation_errors`)
+6. Check for proxy settings in env vars, `/etc/environment`, `/etc/profile.d/`
+7. Assert all validations passed
+
+The hardware specs dicts (e.g., `redis_hw_specs`, `platform_hw_specs`, `mongodb_hw_specs`) are defined in `roles/<component>/vars/platform-release-<N>.yml` and keyed by `env` value.
+
+## Key Variables
+
+| Variable | Default | Source File | Purpose |
+|----------|---------|-------------|---------|
+| `common_itential_release_file` | `/etc/itential-release` | `defaults/main/main.yml` | Path to file tracking installed component versions. Written by each role after install. |
+| `common_install_yum_repos` | `true` | `defaults/main/main.yml` | When `false`, skips YUM repo installation. Set to `false` in `all.vars` to use internal repos. |
+| `offline_install_enabled` | `false` | `defaults/main/offline.yml` | Master switch for air-gapped install mode. |
+| `offline_target_node_root` | `/var/tmp` | `defaults/main/offline.yml` | Root on target nodes for offline package staging. |
+| `offline_control_node_root` | `{{ playbook_dir }}/files` | `defaults/main/offline.yml` | Root on control node where offline packages are staged. |
+| `offline_itential_packages_path` | `itential_packages/{{ ansible_distribution \| lower }}_{{ ansible_distribution_major_version }}` | `defaults/main/offline.yml` | OS-specific subdirectory under the offline roots. |
+
+## Dependencies / Assumptions
+
+- The `common` role has no task dependencies.
+- All other roles depend on `common` being applied first (typically via `role: itential.deployer.common` in the playbook before the component role).
+- `verify-host.yml` requires `gather_facts: true` on the play (it uses `ansible_mounts`, `ansible_memtotal_mb`, `ansible_processor_vcpus`, `ansible_selinux`, etc.).
+
+## Gotchas
+
+- `offline_install_enabled` defaults to `false` here but the `download_packages_*` playbooks override it to `false` explicitly at the play level — the download playbooks always run online even when deploying to offline targets.
+- The `common_itential_release_file` check in the `os` role skips OS package installation if the file already exists, making the `os` role effectively idempotent for re-runs.
+- `verify-host.yml` uses `ignore_errors: true` on individual assertions and collects them, then does a final combined assert. This means a failing host will show all failures rather than stopping at the first.

--- a/roles/gateway/CLAUDE.md
+++ b/roles/gateway/CLAUDE.md
@@ -1,0 +1,182 @@
+# Role: gateway
+
+## Purpose
+
+Installs and configures Itential Automation Gateway (IAG). Handles Python virtualenv creation, pip dependency installation, Ansible collection installation, Nornir configuration, HTTPS TLS certificate deployment, systemd service setup, firewalld, and SELinux.
+
+## Entry Point Tasks — main.yml
+
+1. `validate-vars.yml` (always tagged) — validate PKI variables
+2. Load release vars from `vars/gateway-release-{{ gateway_release }}.yml` (fail if release unsupported)
+3. Create temp working directory
+4. Install dependency packages (`gateway_packages`) — online or offline
+5. Create `itential` group and user (with SSH key generation)
+6. Create working directories under `gateway_install_dir` and `gateway_data_dir`
+7. Create `python-venvs` directory (when `gateway_enable_python_venv: true`)
+8. `configure-gateway-https.yml` — PKI setup and cert copy (when `gateway_pki_copy_certs: true`)
+9. Install Python (include `install-python.yml`)
+10. Install build packages (`gateway_build_packages`) — online only (removed in `always` block)
+11. Install Python dependencies (`install-python-dependencies.yml`)
+12. Configure Ansible (when `gateway_enable_ansible: true`): install collections → create `ansible.cfg` → create empty inventory/vault files
+13. Check if IAG is already installed (`stat` on `venv/automation-gateway`)
+14. Copy or download IAG wheel file when not already installed
+15. `pip install` IAG wheel into `gateway_install_dir/venv`
+16. Set ownership (`chown -R`) and permissions (`chmod -R 775`) on venv
+17. Create `properties.yml` from versioned template
+18. Create Nornir inventory/config files (when `gateway_enable_nornir: true`)
+19. Write `automation-gateway.service` systemd unit
+20. Open firewalld port (HTTP or HTTPS depending on `gateway_https_enabled`)
+21. `configure-selinux.yml`
+22. Copy test scripts to `gateway_install_dir/scripts/`
+23. Start and enable `automation-gateway` service
+24. `update-release-file.yml`
+25. Remove temp working directory
+26. `always` block: remove build packages that were installed; assert service is active
+
+## Key Variables
+
+### gateway.yml defaults
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `gateway_install_dir` | `/opt/automation-gateway` | IAG installation root |
+| `gateway_data_dir` | `/var/lib/automation-gateway` | IAG data directory |
+| `gateway_log_dir` | `/var/log/automation-gateway` | IAG log directory |
+| `gateway_properties_location` | `/etc/automation-gateway` | Properties file directory |
+| `gateway_ansible_collections_path` | `{{ gateway_install_dir }}/ansible/collections` | Ansible collections path |
+| `gateway_port` | `8083` | HTTP listen port |
+| `gateway_https_enabled` | `true` | Enable HTTPS (default on) |
+| `gateway_https_port` | `8443` | HTTPS listen port |
+| `gateway_pki_copy_certs` | `true` | Copy TLS certs from control node |
+| `gateway_tlsv1_2` | `false` | Allow TLSv1.2 (in addition to 1.3) |
+| `gateway_user` | `itential` | OS user for IAG process |
+| `gateway_group` | `itential` | OS group |
+| `gateway_venv_name` | `venv` | Name of the Python virtualenv directory |
+| `gateway_python_venv` | `{{ gateway_install_dir }}/venv` | Path to the Python virtualenv |
+| `gateway_http_server_threads` | `{{ ansible_processor_cores * 4 }}` | IAG HTTP thread count |
+| `gateway_enable_ansible` | `true` | Install Ansible and configure collections |
+| `gateway_enable_nornir` | `true` | Create Nornir config/inventory files |
+| `gateway_enable_netmiko` | `true` | Enable netmiko support |
+| `gateway_enable_scripts` | `true` | Enable script execution |
+| `gateway_enable_netconf` | `true` | Enable NETCONF support |
+| `gateway_enable_httpreq` | `true` | Enable HTTP request feature |
+| `gateway_enable_python_venv` | `true` | Create Python venv directories |
+| `gateway_enable_grpc` | `true` | Enable gRPC support |
+| `gateway_enable_git` | `true` | Enable Git support |
+
+### pki.yml defaults (TLS paths)
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `gateway_pki_base_dir` | `/etc/pki/automation-gateway` | Base PKI directory |
+| `gateway_pki_private_dir` | `{{ gateway_pki_base_dir }}/private` | Private key subdirectory |
+| `gateway_pki_https_dir` | `{{ gateway_pki_base_dir }}/https` | HTTPS cert subdirectory |
+| `gateway_https_cert_file` | `{{ inventory_hostname }}.crt` | HTTPS cert filename |
+| `gateway_https_key_file` | `{{ inventory_hostname }}.key` | HTTPS key filename |
+| `gateway_https_ca_file` | `ca-bundle.crt` | HTTPS CA bundle filename |
+| `gateway_https_cert_dest` | `{{ gateway_pki_https_dir }}/{{ gateway_https_cert_file }}` | Cert destination |
+| `gateway_https_key_dest` | `{{ gateway_pki_private_dir }}/{{ gateway_https_key_file }}` | Key destination |
+| `gateway_https_ca_dest` | `{{ gateway_pki_https_dir }}/{{ gateway_https_ca_file }}` | CA destination |
+| `gateway_pki_src_dir` | `""` | Source dir on control node (required when `gateway_pki_copy_certs: true`) |
+| `gateway_https_cert_src` | `{{ gateway_pki_src_dir }}/{{ gateway_https_cert_file }}` | Cert source |
+| `gateway_https_key_src` | `{{ gateway_pki_src_dir }}/{{ gateway_https_key_file }}` | Key source |
+| `gateway_https_ca_src` | `{{ gateway_pki_src_dir }}/{{ gateway_https_ca_file }}` | CA source |
+
+### offline.yml defaults
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `gateway_target_node_root` | Under `offline_target_node_root` | Target node offline package dir |
+| `gateway_control_node_root` | Under `offline_control_node_root` | Control node offline package dir |
+| `gateway_offline_target_node_rpms_dir` | `{{ gateway_target_node_root }}/rpms` | RPM target dir |
+| `gateway_offline_target_node_wheels_dir` | `{{ gateway_target_node_root }}/wheels` | Wheels target dir |
+| `gateway_offline_control_node_rpms_dir` | `{{ gateway_control_node_root }}/rpms` | RPM source dir (control) |
+| `gateway_offline_control_node_wheels_dir` | `{{ gateway_control_node_root }}/wheels` | Wheels source dir (control) |
+| `gateway_offline_control_node_collections_dir` | `{{ gateway_control_node_root }}/collections` | Collections source dir (control) |
+
+## TLS Configuration
+
+HTTPS is **enabled by default** (`gateway_https_enabled: true`, `gateway_pki_copy_certs: true`).
+
+Flow (`configure-gateway-https.yml`):
+1. Create `gateway_pki_base_dir` (mode `0750`, owned by `itential:itential`)
+2. Create `gateway_pki_https_dir` (mode `0750`)
+3. Create `gateway_pki_private_dir` (mode `0700`)
+4. Call `copy-certs.yml` to copy `{{ inventory_hostname }}.crt`, `{{ inventory_hostname }}.key`, and `ca-bundle.crt` from `gateway_pki_src_dir` on the control node
+
+The PKI infrastructure is created unconditionally when `gateway_pki_copy_certs: true`, regardless of `gateway_https_enabled`. This allows certs to be in place even if HTTPS is enabled later. The `properties.yml` template references the cert/key paths when `gateway_https_enabled: true`.
+
+**`gateway_pki_src_dir` must be set in inventory** when `gateway_pki_copy_certs: true`. The `validate-vars.yml` task will fail if it is empty.
+
+To disable HTTPS entirely:
+```yaml
+gateway_https_enabled: false
+gateway_pki_copy_certs: false
+```
+
+## Templates
+
+| Template | Rendered To | Purpose |
+|----------|-------------|---------|
+| `properties.4.3.yml.j2` | `/etc/automation-gateway/properties.yml` | IAG properties for release 4.3 (port, TLS, Ansible paths, feature flags) |
+| `properties.4.2.yml.j2` | `/etc/automation-gateway/properties.yml` | IAG properties for release 4.2 |
+| `properties.2023.3.yml.j2` | (legacy) | Legacy release templates |
+| `properties.2023.2.yml.j2` | (legacy) | Legacy release templates |
+| `properties.2023.1.yml.j2` | (legacy) | Legacy release templates |
+| `properties.2022.1.yml.j2` | (legacy) | Legacy release templates |
+| `properties.2021.2.yml.j2` | (legacy) | Legacy release templates |
+| `properties.2021.1.yml.j2` | (legacy) | Legacy release templates |
+| `automation-gateway.service.j2` | `/etc/systemd/system/automation-gateway.service` | Systemd unit |
+| `ansible.cfg.j2` | `/etc/ansible/ansible.cfg` | Ansible configuration for IAG's internal Ansible |
+| `nornir.config.yml.j2` | `{{ gateway_install_dir }}/nornir/config.yml` | Nornir configuration |
+| `gateway.preflight.j2` | Used by `preflight.yml` | Pre-install checklist output |
+
+## Handlers
+
+| Handler | Listen String | Action |
+|---------|--------------|--------|
+| Restart automation-gateway | `restart automation-gateway` | `systemctl restart automation-gateway` |
+
+## Release-Specific Vars (vars/gateway-release-4.3.yml)
+
+| Variable | Value |
+|----------|-------|
+| `gateway_python_version` | `3.9` |
+| `gateway_python_packages` | `python39`+`python39-pip` (RHEL 8); `python3`+`python3-pip` (RHEL 9, AL2023) |
+| `gateway_python_base_dependencies` | `pip==24.0`, `setuptools==78.1.1`, `wheel==0.43.0` |
+| `gateway_python_wheel_build_dependencies` | `ansible-pylibssh==1.3.0`, `ncclient==0.6.19`, `netifaces==0.10.9`, `pygnmi==0.8.9`, `mypy_extensions==0.4.4` |
+| `gateway_build_packages` | `gcc-c++`, `libssh-devel`, `make`, `pkgconf-pkg-config`, `python3(9)-devel` |
+
+Release 4.2 uses the same package sets but different pinned versions (e.g., `setuptools==69.0.3`, `ncclient==0.6.10`).
+
+Supported `gateway_release` values: `4.2`, `4.3`. Legacy date-format releases (`2021.1` through `2023.3`) have property templates but no dedicated vars files.
+
+## IAG Installation Methods
+
+The role supports two ways to provide the IAG wheel:
+
+1. **Local file**: Set `gateway_whl_file` to the filename relative to `playbook_dir/files/`. The role copies it to the target's temp dir.
+2. **Repository download**: Set `gateway_archive_download_url` to the full URL. The role downloads it on the target node using `get_url` with JFrog or Nexus credentials. Sets `gateway_whl_file` from the download result.
+
+Only one of `gateway_whl_file` or `gateway_archive_download_url` should be set.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `files/scripts/verify-iag-environment.py` | Python script copied to `gateway_install_dir/scripts/` for post-install environment verification |
+
+## Dependencies / Assumptions
+
+- The `common` role must be applied first (for `offline_install_enabled`, `common_install_yum_repos`).
+- `gateway_release` must be defined in the inventory under the `gateway` group vars.
+- `gateway_whl_file` or `gateway_archive_download_url` must be defined (the role does not fail fast on this — it will fail at the pip install step if neither is set and IAG is not already installed).
+
+## Gotchas
+
+- Build packages (`gcc`, `libssh-devel`, `make`, etc.) are installed to compile Python wheel dependencies, then removed in the `always` block — even if the play fails. This cleanup runs unconditionally.
+- The IAG install is skipped if `{{ gateway_install_dir }}/venv/automation-gateway` already exists (`stat` check). To force reinstall, remove this file/symlink first.
+- `gateway_http_server_threads` defaults to `ansible_processor_cores * 4`. On systems where `ansible_processor_cores` is unavailable or 0, this will produce 0 threads. Verify the value is sensible on target hardware.
+- `gateway_pki_copy_certs: true` runs unconditionally when set, regardless of `gateway_https_enabled`. This means if you disable HTTPS but leave `gateway_pki_copy_certs: true`, the role will still try to copy certs (and fail if `gateway_pki_src_dir` is empty).
+- The Ansible `ansible.cfg` written to `/etc/ansible/ansible.cfg` sets the collections path to `gateway_ansible_collections_path`. If `/etc/ansible/ansible.cfg` already exists, it is backed up but replaced.
+- The `gateway_release` variable maps to both a vars file (`vars/gateway-release-<N>.yml`) and a properties template (`templates/properties.<N>.yml.j2`). Adding a new release requires both files.

--- a/roles/mongodb/CLAUDE.md
+++ b/roles/mongodb/CLAUDE.md
@@ -1,0 +1,180 @@
+# Role: mongodb
+
+## Purpose
+
+Installs and configures MongoDB for use with Itential Platform. Handles single-node and replica set deployments, user creation, authentication, TLS, kernel tuning, SELinux policy modules, NUMA configuration, logrotate, and firewalld port opening.
+
+## Entry Point Tasks — main.yml
+
+1. `validate-vars.yml` (always tagged) — validates required variables
+2. Set node type facts: `mongodb_is_primary_node`, `mongodb_is_replica_node`, `mongodb_data_nodes`
+3. `install-mongodb.yml` — full install sequence (notifies `Update Itential release file` handler)
+4. `configure-mongodb.yml` — conditional configuration (skipped if auth, TLS, and replication are all disabled)
+5. Assert `mongod` service is `active`
+
+## install-mongodb.yml Sequence
+
+1. Install MongoDB packages (online: adds MongoDB YUM repo then `dnf install`; offline: `offline/install-rpms`)
+2. Pin MongoDB in `/etc/dnf/dnf.conf` with `exclude=mongodb-org*`
+3. Create `mongodb_data_dir`, `mongodb_log_dir`, `mongodb_pid_dir`
+4. Install Python (for `community.mongodb` collection)
+5. Configure Transparent Huge Pages (THP): disable for MongoDB < 8.0; enable + tune for >= 8.0
+6. Adjust kernel parameters (`sysctl`)
+7. Configure SELinux (when enforcing) via the `selinux` role
+8. Configure logrotate
+9. Configure NUMA
+10. Open firewalld port `mongodb_port/tcp`
+11. Write initial `mongod.conf` with `stage: initialize` (auth/TLS/replication forced off)
+12. Start `mongod`
+13. Use `itential.deployer.mongodb_config_state` module to discover current auth/replication state
+14. Create `admin`, `itential`, and optionally `monitor` database users (runs only on `mongodb_primary[0]`)
+
+## configure-mongodb.yml Sequence
+
+Conditionally includes (in order):
+
+1. `configure-mongodb-replicaset.yml` — when `mongodb_replica` group has members
+2. `configure-mongodb-auth.yml` — when `mongodb_auth_enabled`
+3. `configure-mongodb-tls.yml` — when `mongodb_tls_enabled`
+
+## Key Variables
+
+### mongodb.yml defaults
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `mongodb_conf_file` | `/etc/mongod.conf` | Path to mongod config |
+| `mongodb_data_dir` | `/var/lib/mongo` | Data directory |
+| `mongodb_log_dir` | `/var/log/mongodb` | Log directory |
+| `mongodb_pid_dir` | `/var/run/mongodb` | PID directory |
+| `mongodb_owner` | `mongod` | OS user/group for MongoDB files |
+| `mongodb_group` | `mongod` | OS group |
+| `mongodb_port` | `27017` | Listen port |
+| `mongodb_bind_addrs` | `127.0.0.1` | Bind addresses (inventory_hostname and optionally `::1` added automatically) |
+| `mongodb_bind_ipv6` | `true` | Add `::1` to bind addresses |
+| `mongodb_auth_enabled` | `true` | Enable MongoDB authentication |
+| `mongodb_tls_enabled` | `true` | Enable TLS |
+| `mongodb_tls_copy_certs` | `true` | Copy certs from control node to target |
+| `mongodb_replication_enabled` | `false` | Enable replica set configuration |
+| `mongodb_replset_name` | `rs0` | Replica set name |
+| `mongodb_user_admin` | `admin` | Admin user name |
+| `mongodb_user_itential` | `itential` | App user name |
+| `mongodb_user_admin_password` | `admin` | Admin password (change in production) |
+| `mongodb_user_itential_password` | `itential` | App password (change in production) |
+| `mongodb_user_monitor_password` | `monitor` | Monitor user password |
+| `mongodb_monitor_user_enabled` | `false` | Create the monitor user |
+| `mongodb_primary_priority` | `10` | Replica priority for `mongodb_primary` group hosts |
+| `mongodb_replica_priority` | `5` | Default replica priority for `mongodb_replica` group hosts |
+| `mongodb_certify_report_dir_remote` | `/var/tmp/itential-reports/mongodb` | Report dir on target |
+| `mongodb_certify_report_dir_local` | `/tmp/itential-reports/mongodb` | Report dir on control node |
+
+### kernel_params.yml defaults
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `mongodb_sysctl_file` | `/etc/sysctl.d/98-mongodb.conf` | Sysctl config file path |
+| `mongodb_net_ipv4_tcp_keepalive_time` | `300` | TCP keepalive |
+| `mongodb_net_core_somaxconn` | `65535` | Max socket connections |
+| `mongodb_vm_zone_reclaim_mode` | `0` | NUMA zone reclaim mode |
+| `mongodb_vm_swappiness` | `1` | VM swappiness |
+| `mongodb_vm_max_map_count` | `262144` | Max memory map areas |
+
+### install.yml defaults (runtime-computed)
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `mongodb_python_executable` | `/usr/bin/python3` | System Python |
+| `mongodb_pip_executable` | `/usr/bin/pip3` | System pip |
+| `mongodb_python_venv` | `/usr/local/lib/mongodb_venv` | Python venv for `community.mongodb` |
+| `mongodb_mongod_service_retries` | `5` | Retries when starting mongod |
+| `mongodb_mongod_service_delay` | `10` | Seconds between retries |
+
+### pki.yml defaults (TLS paths)
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `mongodb_pki_base_dir` | `/etc/pki/mongodb` | Base PKI directory |
+| `mongodb_pki_private_dir` | `{{ mongodb_pki_base_dir }}/private` | Private key subdirectory |
+| `mongodb_tls_server_cert_file` | `{{ inventory_hostname }}.pem` | Combined cert+key PEM filename |
+| `mongodb_tls_ca_file` | `ca-bundle.crt` | CA bundle filename |
+| `mongodb_auth_key_file` | `replica.key` | Replica set keyfile filename |
+| `mongodb_tls_cert_dest` | `{{ mongodb_pki_base_dir }}/{{ mongodb_tls_server_cert_file }}` | Cert destination on target |
+| `mongodb_tls_ca_dest` | `{{ mongodb_pki_base_dir }}/{{ mongodb_tls_ca_file }}` | CA destination on target |
+| `mongodb_auth_key_dest` | `{{ mongodb_pki_private_dir }}/{{ mongodb_auth_key_file }}` | Keyfile destination on target |
+| `mongodb_pki_src_dir` | `""` | Source directory on control node (must be set in inventory when TLS enabled) |
+| `mongodb_tls_cert_src` | `{{ mongodb_pki_src_dir }}/{{ mongodb_tls_server_cert_file }}` | Cert source |
+| `mongodb_tls_ca_src` | `{{ mongodb_pki_src_dir }}/{{ mongodb_tls_ca_file }}` | CA source |
+
+## TLS Configuration
+
+TLS is **enabled by default** (`mongodb_tls_enabled: true`, `mongodb_tls_copy_certs: true`).
+
+Flow (`configure-mongodb-tls.yml`):
+1. When `mongodb_tls_copy_certs: true`: create PKI directories, then call `copy-certs.yml` to copy cert files from `mongodb_pki_src_dir` on the control node
+2. Write `mongod.conf` with `stage: tls` (enables TLS settings in the template)
+3. Flush handlers (restarts mongod immediately with TLS config)
+
+**`mongodb_pki_src_dir` must be set in inventory** when `mongodb_tls_copy_certs: true`. The cert file is `<inventory_hostname>.pem` (combined cert + key in PEM format) — MongoDB requires a single PEM with both. The replica keyfile (`replica.key`) is only needed when `mongodb_replication_enabled: true`.
+
+To disable TLS (e.g., AIO dev environments):
+```yaml
+mongodb_tls_enabled: false
+mongodb_tls_copy_certs: false
+```
+
+## Templates
+
+| Template | Rendered To | Purpose |
+|----------|-------------|---------|
+| `mongod.conf.j2` | `/etc/mongod.conf` | Main mongod configuration; rendered multiple times with different `stage` values (`initialize`, `auth`, `tls`) |
+| `mongod.logrotate.j2` | `/etc/logrotate.d/mongod` | Logrotate configuration |
+| `thp.service.j2` | `/etc/systemd/system/thp.service` | Systemd service to set THP state on boot (only for MongoDB < 8.0) |
+| `tuned.conf.j2` | `/etc/tuned/mongodb/tuned.conf` | Tuned profile for MongoDB |
+| `mongodb.preflight.j2` | Used by `preflight.yml` | Pre-install checklist output |
+| `mongodb-validation-report.md.j2` | `mongodb_certify_report_dir_remote/<host>.md` | Certification report |
+
+## Handlers
+
+| Handler | Trigger | Action |
+|---------|---------|--------|
+| `restart mongod` | `notify: restart mongod` | `systemctl restart mongod` |
+| `Update Itential release file` | `notify: Update Itential release file` | Includes `update-release-file.yml` to write component version to `/etc/itential-release` |
+
+## Inventory Groups
+
+| Group | Nodes |
+|-------|-------|
+| `mongodb_primary` | Primary data node (required) |
+| `mongodb_replica` | Secondary data nodes (optional) |
+| `mongodb_arbiter` | Arbiter nodes (optional) |
+| `mongodb` | All of the above (used in the `mongodb.yml` playbook host target) |
+
+The `mongodb_primary[0]` host runs user creation tasks. All hosts in `mongodb_primary` get `mongodb_is_primary_node: true` and priority `mongodb_primary_priority`.
+
+## Release-Specific Vars (vars/platform-release-6.yml)
+
+| Variable | RHEL 8/9/2023 default |
+|----------|----------------------|
+| `mongodb_version` | `8.0` |
+| `mongodb_packages` | `mongodb-org` (+ `mongodb-mongosh-shared-openssl3` on Amazon 2023) |
+| `mongodb_package_dependencies` | `selinux-policy`, `selinux-policy-targeted`, `audit`, `tuned` (tuned excluded on Amazon 2023) |
+| `mongodb_python_packages` | `python39`+`python39-pip` (RHEL 8); `python3`+`python3-pip` (RHEL 9, AL2023) |
+
+Hardware specs for `verify` playbook (`mongodb_hw_specs`):
+- dev: 8 CPU, 64 GB RAM, 1000 GB disk
+- test/prod: 16 CPU, 128 GB RAM, 1000 GB disk
+
+## Dependencies / Assumptions
+
+- The `common` role must be applied first.
+- The `community.mongodb` collection must be installed on the control node.
+- Python 3 must be available on the target node for `community.mongodb` tasks (the role installs it).
+- When `mongodb_tls_enabled: true` and `mongodb_tls_copy_certs: true`, the certificate file at `{{ mongodb_pki_src_dir }}/{{ inventory_hostname }}.pem` must contain both the certificate and private key concatenated.
+
+## Gotchas
+
+- The mongod config is written three times during install: `initialize` (no auth/TLS), after auth setup, and after TLS setup. Each write triggers a mongod restart via the handler.
+- The `mongodb_config_state` custom module determines whether to create users idempotently — it queries MongoDB directly and checks for existing auth/replication config. This module uses the `mongodb_python_venv` interpreter.
+- User creation runs only on `mongodb_primary[0]` even in replica set mode, which is correct because MongoDB replicates users across the set.
+- When `replication_enabled: true`, replica set initiation must happen before auth is enabled. The `configure-mongodb-replicaset.yml` task runs first for this reason.
+- THP behavior changed at MongoDB 8.0: older versions require THP disabled; 8.0+ requires THP enabled. The role checks `mongodb_version | float` to decide which task file to run.

--- a/roles/offline/CLAUDE.md
+++ b/roles/offline/CLAUDE.md
@@ -1,0 +1,93 @@
+# Role: offline
+
+## Purpose
+
+Shared utility role providing reusable tasks for downloading packages (RPMs, Python wheels, adapters, Ansible collections) to the control node and installing them from the control node onto target nodes in air-gapped deployments. Has no `main.yml` — all task files are called via `tasks_from:` by other roles.
+
+## Task Files
+
+| File | Called By | Purpose |
+|------|-----------|---------|
+| `download-rpms.yml` | Component roles' `download-packages.yml` | Downloads RPM packages to a specified directory using one of several methods |
+| `download-wheels.yml` | Component roles' `download-packages.yml` | Downloads Python wheel packages using `pip download` |
+| `download-adapters.yml` | `platform/download-packages.yml` | Downloads multiple platform adapters |
+| `download-adapter.yml` | `download-adapters.yml` | Downloads a single adapter (looped) |
+| `install-rpms.yml` | Component role task files | Copies RPMs from control node to target and installs via dnf or rpm |
+| `install-wheels.yml` | Component role task files | Installs Python wheels from control node into a venv or via pip |
+| `install-wheels-archives.yml` | Component role task files | Installs multiple wheel archives |
+| `install-wheels-archive.yml` | `install-wheels-archives.yml` | Installs a single wheel archive (looped) |
+| `install-adapter.yml` | `platform/install-adapters.yml` | Installs a single adapter archive |
+| `fetch-packages.yml` | Component roles' `download-packages.yml` | Copies downloaded packages from target node back to control node (fetch) |
+
+## download-rpms.yml
+
+Requires the caller to set:
+
+| Variable | Values | Purpose |
+|----------|--------|---------|
+| `offline_download_dir` | path | Directory on target to download RPMs into |
+| `offline_download_method` | `yum_module`, `yum_install`, `yum_reinstall`, `repotrack`, `yumdownloader`, `get_url` | Which download mechanism to use |
+| `offline_download_packages` | list | Package names or URLs to download |
+
+Supports `repository_api_key` (JFrog/GitLab) and `repository_username`/`repository_password` (Nexus) for `get_url` method.
+
+## install-rpms.yml
+
+Requires the caller to set:
+
+| Variable | Purpose |
+|----------|---------|
+| `offline_rpms_path` | Path on the control node glob-matched for `*.rpm` files to copy and install |
+
+Process: creates temp dir → copies RPMs → rebuilds RPM DB → disables all repos → installs via dnf with `cacheonly: true` and `disable_gpg_check: true`. Optionally uses `rpm -i` directly if `offline_use_rpm_cmd: true`.
+
+## fetch-packages.yml
+
+Requires:
+
+| Variable | Purpose |
+|----------|---------|
+| `offline_src_dir` | Directory on target node containing downloaded packages |
+| `offline_dest_dir` | Directory on control node to fetch packages into |
+
+Uses `ansible.builtin.fetch` with `flat: true`.
+
+## Offline Directory Structure
+
+The offline directory paths are built by each component role using variables from `common/defaults/main/offline.yml`:
+
+```
+{{ offline_control_node_root }}/
+  {{ offline_itential_packages_path }}/
+    {{ platform_release }}/platform/
+      rpms/dependencies/
+      rpms/nodejs/
+      rpms/os/
+      wheels/
+      adapters/
+    {{ gateway_release }}/gateway/
+      rpms/dependencies/
+      rpms/python/
+      rpms/build/
+      wheels/
+      collections/
+    mongodb/
+      rpms/
+      wheels/
+    redis/
+      rpms/build/
+      rpms/security/
+      archives/
+```
+
+## Dependencies / Assumptions
+
+- This role has no defaults. All variables are passed by the calling role's task files.
+- The role is always included (not applied independently) — it appears in `roles:` only in `download_packages_*` playbooks where `offline_install_enabled` is forced to `false`.
+- `install-rpms.yml` uses `dnf` with all repos disabled, relying on the packages being fully self-contained (with all dependencies pre-downloaded).
+
+## Gotchas
+
+- `offline_use_rpm_cmd` is an escape hatch for environments where `dnf` with `cacheonly` fails. It uses `rpm -i` with options from `offline_rpm_cmd_opts` (caller must set this).
+- `download-rpms.yml` with `repotrack` runs `repotrack` from the download directory (`chdir`), not with `--download-path`. Verify `repotrack` behavior on the target OS version.
+- The `get_url` method in `download-rpms.yml` only processes packages where `'http' in package` and `package.endswith('.rpm')` — non-URL entries are silently skipped.

--- a/roles/os/CLAUDE.md
+++ b/roles/os/CLAUDE.md
@@ -1,0 +1,63 @@
+# Role: os
+
+## Purpose
+
+Installs base OS, security, and operational packages required by all Itential components. Targets RedHat-family hosts only. Skips entirely if `/etc/itential-release` already exists (idempotency guard).
+
+## Entry Point Tasks — main.yml
+
+1. Stat `/etc/itential-release` (from `common_itential_release_file`)
+2. Fail if `ansible_os_family` is not `redhat`
+3. Include `redhat.yml` when the release file does not exist
+
+### redhat.yml
+
+1. Load OS-version-specific vars from `vars/release-<major>.yml` (falls through to `release-undefined.yml` which sets `invalid_os_release` to fail)
+2. Fail if OS major version is unsupported
+3. Include `redhat-online.yml` when `not offline_install_enabled`
+4. Include `redhat-offline.yml` when `offline_install_enabled`
+
+### redhat-online.yml
+
+Installs `os_packages`, `security_packages`, and `operational_packages` via `dnf`.
+
+### redhat-offline.yml
+
+Installs the same package groups using the `offline` role's `install-rpms` task file.
+
+### download-packages.yml (called by `download_packages_os.yml` playbook)
+
+Downloads all OS package RPMs to the offline staging directory using the `offline` role's `download-rpms` task file.
+
+## Key Variables
+
+There are no `defaults/` variables in this role. Package lists come from `vars/release-<N>.yml`.
+
+| Variable | Defined In | Purpose |
+|----------|-----------|---------|
+| `os_packages` | `vars/release-8.yml`, `vars/release-9.yml` | Core OS packages (e.g., `coreutils`, `openssl`) |
+| `security_packages` | `vars/release-8.yml`, `vars/release-9.yml` | SELinux policy packages, `policycoreutils`, `checkpolicy` |
+| `operational_packages` | `vars/release-8.yml`, `vars/release-9.yml` | Ops tooling: `git`, `curl`, `jq`, `tcpdump`, `tar`, etc. |
+| `invalid_os_release` | `vars/release-undefined.yml` | Defined only when OS version is unsupported; triggers a fail |
+| `offline_install_enabled` | `common/defaults/main/offline.yml` | Controls online vs offline install path |
+| `offline_*_dir` | `defaults/main/offline.yml` | Offline staging directories |
+
+### RHEL 8 Package Lists (vars/release-8.yml)
+
+- `os_packages`: `coreutils`, `openssl`
+- `security_packages`: `checkpolicy`, `libselinux`, `libselinux-utils`, `policycoreutils`, `policycoreutils-python-utils`, `selinux-policy-mls`
+- `operational_packages`: `bind-utils`, `curl`, `dos2unix`, `git`, `gzip`, `jq`, `man`, `rsyslog`, `sudo`, `sysstat`, `tar`, `tcpdump`, `telnet`, `unzip`, `wget`, `which`, `zip`
+
+RHEL 9 uses the same lists (identical `vars/release-9.yml`).
+
+## Dependencies / Assumptions
+
+- Requires the `common` role to have been applied first (for `common_itential_release_file` and `offline_install_enabled`).
+- The `os.yml` playbook targets: `platform`, `platform_secondary`, `redis`, `redis_secondary`, `mongodb`, `mongodb_arbiter`, `gateway`.
+- The `os` role is not applied automatically as part of the main component roles (it is a separate playbook step in `site.yml` predecessors). Check whether `os.yml` was run separately if packages are missing.
+
+## Gotchas
+
+- The role skips entirely if `/etc/itential-release` exists. This means re-runs on already-installed hosts do nothing, even if new packages were added to the vars files.
+- `vars/release-undefined.yml` defines `invalid_os_release` to trigger the fail task — do not set this variable in your inventory.
+- The offline path (`redhat-offline.yml`) requires offline RPMs to have been staged at the path built from `offline_control_node_root` and `offline_itential_packages_path`.

--- a/roles/platform/CLAUDE.md
+++ b/roles/platform/CLAUDE.md
@@ -1,0 +1,237 @@
+# Role: platform
+
+## Purpose
+
+Installs and configures Itential Platform (IAP). Handles OS user/directory setup, NodeJS installation, Python installation, RPM package installation, adapter installation, optional app artifacts, HTTPS and MongoDB client TLS certificate deployment, Vault integration, SELinux, firewalld, and service startup.
+
+## Entry Point Tasks — main.yml
+
+1. `validate-vars.yml` (always tagged) — validates required variables and loads release-specific vars
+2. Configure OS:
+   a. `create-itential-user.yml` — create `itential` user and group
+   b. Create directories: `platform_server_dir`, `platform_config_dir`, `platform_log_dir`
+   c. Add sudoers entry for `chroot` (required by TemplateBuilder)
+   d. `configure-firewalld.yml` — open HTTP and HTTPS ports
+3. Install Dependencies, Platform, Adapters, App Artifacts (notifies `Update Itential release file`):
+   a. `install-platform-dependency-packages.yml` — install OS packages
+   b. `install-nodejs.yml` — install NodeJS
+   c. `install-python.yml` — install Python
+   d. `install-platform.yml` — install IAP RPM packages
+   e. `install-adapters.yml` — install configured adapters
+   f. `install-app-artifacts.yml` — when `platform_app_artifacts_enabled: true`
+4. `configure-selinux.yml` — apply SELinux configuration
+5. `configure-vault.yml` — when `platform_configure_vault: true`
+6. `copy-certs.yml` — when `platform_webserver_https_copy_certs` or `platform_mongodb_copy_certs` is true
+7. `configure-platform.yml` — write `properties.json` and other config
+8. `start-service.yml` — start `itential-platform` systemd service
+
+## validate-vars.yml
+
+- Asserts `platform_packages` is defined and contains only `.rpm` files (online installs)
+- Asserts repo credentials when packages are downloaded from HTTP URLs
+- Asserts `platform_release` is defined OR all individual vars (`platform_nodejs_package`, `platform_python_version`, `platform_python_packages`, `platform_python_app_dependencies`) are defined
+- Asserts `platform_encryption_key` is a 64-character hex string
+- Validates Vault variables when `platform_configure_vault: true`
+- Validates PKI source directories when copy-certs flags are enabled
+- Loads `vars/platform-release-<N>.yml` and sets release-specific defaults for NodeJS/Python when not overridden in inventory
+
+## Key Variables
+
+### platform.yml defaults
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `platform_root_dir` | `/opt/itential/platform` | Platform install root |
+| `platform_config_dir` | `/etc/itential` | Config directory |
+| `platform_log_dir` | `/var/log/itential/platform` | Log directory |
+| `platform_user` | `itential` | OS user running the service |
+| `platform_group` | `itential` | OS group |
+| `platform_package_dependencies` | `glibc-common`, `openldap`, `openldap-clients`, `openssl`, `git` | OS packages required before Platform RPM |
+| `platform_encryption_key` | (required) | 64-char hex string (256-bit AES key); generate with `openssl rand -hex 32` |
+| `platform_packages` | (required) | List of RPM package names or download URLs |
+| `platform_app_artifacts_enabled` | `false` | Install app artifacts |
+| `platform_start_service` | `true` | Start the service after install |
+| `platform_upload_using_rsync` | `false` | Use rsync for artifact upload |
+| `platform_delete_package_lock_file` | `true` | Delete package-lock.json before npm install |
+| `platform_npm_ignore_scripts` | `true` | Skip npm scripts during install |
+| `platform_certify_report_dir_remote` | `/var/tmp/itential-reports/platform` | Report dir on target |
+| `platform_certify_report_dir_local` | `/tmp/itential-reports/platform` | Report dir on control node |
+
+### server.yml defaults
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `platform_server_id` | `{{ inventory_hostname }}` | Unique server identifier in multi-node deployments |
+| `platform_encrypted` | `true` | Platform uses encrypted code files |
+| `platform_task_worker_enabled` | `true` | Start task worker on boot |
+| `platform_job_worker_enabled` | `true` | Allow jobs to start on boot |
+| `platform_service_launch_timeout` | `600` | Seconds before adapter launch is considered failed |
+| `platform_shutdown_timeout` | `3` | Seconds to wait before forcing shutdown |
+| `platform_audit_enabled` | `false` | Enable detailed audit events |
+
+### webserver.yml defaults
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `platform_webserver_http_enabled` | `true` | Enable HTTP listener |
+| `platform_webserver_http_port` | `3000` | HTTP port |
+| `platform_webserver_https_enabled` | `true` | Enable HTTPS listener |
+| `platform_webserver_https_port` | `3443` | HTTPS port |
+| `platform_webserver_https_ciphers` | Long cipher list | Allowed TLS ciphers |
+| `platform_webserver_https_secure_protocol` | `TLS_method` | OpenSSL method |
+| `platform_webserver_cache_control_enabled` | `false` | HTTP cache control headers |
+| `platform_webserver_timeout` | `300000` | Request timeout (ms) |
+
+### mongodb.yml defaults
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `platform_mongo_auth_enabled` | `true` | Use MongoDB auth |
+| `platform_mongo_user` | `itential` | MongoDB username |
+| `platform_mongo_password` | `itential` | MongoDB password (change in production) |
+| `platform_mongo_db_name` | `itential` | MongoDB database name |
+| `platform_mongo_url` | `mongodb://localhost:27017` | MongoDB connection string |
+| `platform_mongo_tls_enabled` | `true` | Use TLS for MongoDB connection |
+| `platform_mongo_tls_allow_invalid_certificates` | `false` (when TLS enabled) | Accept invalid/self-signed certs |
+| `platform_mongo_bypass_version_check` | `false` | Skip MongoDB version compatibility check |
+
+### redis.yml defaults
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `platform_redis_auth_enabled` | `true` | Use Redis auth |
+| `platform_redis_username` | `itential` | Redis username |
+| `platform_redis_password` | `itential` | Redis password (change in production) |
+| `platform_redis_host` | `localhost` | Redis host (not used when sentinels are configured) |
+| `platform_redis_port` | `6379` | Redis port |
+| `platform_redis_sentinels` | (empty) | List of `{host, port}` dicts for Sentinel-based HA |
+| `platform_redis_sentinel_username` | `sentineluser` | Sentinel username |
+| `platform_redis_sentinel_password` | `sentineluser` | Sentinel password |
+| `platform_redis_name` | `itentialmaster` | Redis primary name (must match `redis_sentinel_master_name`) |
+| `platform_redis_tls` | (empty) | TLS options dict for NodeJS Redis client |
+
+### pki.yml defaults (TLS paths)
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `platform_pki_base_dir` | `/etc/pki/itential-platform` | Base PKI directory |
+| `platform_pki_https_dir` | `{{ platform_pki_base_dir }}/https` | HTTPS cert subdirectory |
+| `platform_pki_private_dir` | `{{ platform_pki_base_dir }}/private` | Private key subdirectory |
+| `platform_mongodb_pki_dir` | `{{ platform_pki_base_dir }}/mongodb` | MongoDB client cert subdirectory |
+| `platform_webserver_https_copy_certs` | `true` | Copy HTTPS certs from control node |
+| `platform_mongodb_copy_certs` | `true` | Copy MongoDB CA from control node |
+| `platform_https_cert_file` | `{{ inventory_hostname }}.crt` | HTTPS cert filename |
+| `platform_https_key_file` | `{{ inventory_hostname }}.key` | HTTPS key filename |
+| `platform_https_ca_file` | `ca-bundle.crt` | HTTPS CA bundle filename |
+| `platform_mongodb_ca_file` | `ca-bundle.crt` | MongoDB CA bundle filename |
+| `platform_https_pki_src_dir` | `""` | HTTPS cert source dir on control node |
+| `platform_mongodb_pki_src_dir` | `""` | MongoDB cert source dir on control node |
+| `platform_mongo_tls_ca_file` | `{{ platform_mongodb_ca_dest }}` or `""` | CA file path in properties (empty when TLS disabled) |
+
+### authentication.yml defaults
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `platform_default_user_enabled` | `true` | Enable built-in admin user |
+| `platform_default_user_username` | `admin` | Default admin username |
+| `platform_default_user_password` | `admin` | Default admin password (change in production) |
+| `platform_auth_session_ttl` | `60` | Session timeout (minutes) |
+| `platform_auth_unique_sessions_enabled` | `false` | Log out existing sessions on new login |
+
+### vault.yml defaults
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `platform_configure_vault` | `false` | Enable Vault integration |
+| `platform_vault_url` | `http://localhost:8200` | Vault server URL |
+| `platform_vault_auth_method` | `token` | `token` or `approle` |
+| `platform_vault_token` | (required if token auth) | Vault token |
+| `platform_vault_role_id` | (required if approle) | AppRole role ID |
+| `platform_vault_secret_id` | (required if approle) | AppRole secret ID |
+| `platform_vault_read_only` | `true` | Read-only Vault access |
+
+### logging.yml defaults
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `platform_log_level` | `info` | File log level |
+| `platform_log_level_console` | `warn` | Console log level |
+| `platform_log_max_files` | `100` | Max rotated log files |
+| `platform_log_max_file_size` | `1048576` | Max log file size (bytes; ~1 MB) |
+| `platform_log_filename` | `platform.log` | Primary log filename |
+
+## TLS Configuration
+
+HTTPS and MongoDB client TLS are both **enabled by default** (copy-certs flags default to `true`).
+
+**HTTPS certs** (`platform_webserver_https_copy_certs: true`):
+- Source: `{{ platform_https_pki_src_dir }}/{{ inventory_hostname }}.crt` and `.key` and `ca-bundle.crt`
+- Destination: `/etc/pki/itential-platform/https/` (cert, CA) and `private/` (key)
+- Ownership: root:itential; private key mode 0640
+
+**MongoDB client CA** (`platform_mongodb_copy_certs: true`):
+- Source: `{{ platform_mongodb_pki_src_dir }}/ca-bundle.crt`
+- Destination: `/etc/pki/itential-platform/mongodb/ca-bundle.crt`
+- Used by Platform's MongoDB driver to validate the server certificate
+
+To disable all TLS cert management:
+```yaml
+platform_webserver_https_copy_certs: false
+platform_mongodb_copy_certs: false
+platform_webserver_https_enabled: false
+platform_mongo_tls_enabled: false
+```
+
+## Templates
+
+| Template | Rendered To | Purpose |
+|----------|-------------|---------|
+| `6-properties.j2` | `/etc/itential/properties.json` | Main Platform properties file (MongoDB, Redis, webserver, auth, Vault, logging, etc.) |
+| `itential-platform.service.j2` | `/etc/systemd/system/itential-platform.service` | Systemd unit for Platform |
+| `iag_adapter_service_config.j2` | IAG adapter config path | IAG adapter service configuration |
+| `platform.preflight.j2` | Used by `preflight.yml` | Pre-install checklist output |
+| `platform-validation-report.md.j2` | `platform_certify_report_dir_remote/<host>.md` | Certification report |
+
+## Handlers
+
+| Handler | Listen String | Action |
+|---------|--------------|--------|
+| Enable and Start Platform | `restart itential-platform` | `systemctl restart itential-platform` (only when `platform_start_service: true`) |
+| Update Itential release file | (separate notify) | Includes `update-release-file.yml` |
+
+## Inventory Groups
+
+| Group | Description |
+|-------|-------------|
+| `platform` | Primary Platform nodes |
+| `platform_secondary` | Secondary Platform nodes (same role applied) |
+
+Both groups receive the same role. The `platform_server_id` defaults to `inventory_hostname` to uniquely identify each node in a multi-node deployment.
+
+## Release-Specific Vars (vars/platform-release-6.yml)
+
+| Variable | RHEL 8 | RHEL 9 / AL2023 |
+|----------|--------|-----------------|
+| `platform_nodejs_package` | `@nodejs:20/common` | `@nodejs:20` / `nodejs20` |
+| `platform_python_version` | `3.11` | `3.11` |
+| `platform_python_packages` | `python3.11`, `python3.11-pip` | same |
+| `platform_python_app_dependencies` | `jinja2==3.1.2`, `markupsafe==2.1.4`, `textfsm==1.1.3` | same |
+
+Hardware specs for `verify` playbook (`platform_hw_specs`):
+- dev: 8 CPU, 32 GB RAM, 250 GB disk
+- test/prod: 16 CPU, 64 GB RAM, 250 GB disk
+
+## Dependencies / Assumptions
+
+- MongoDB and Redis must be running and accessible before Platform starts.
+- `platform_encryption_key` is a mandatory 64-char hex string. The validate-vars task fails fast if missing or malformed.
+- `platform_packages` must be either local RPM filenames (relative to `playbook_dir/files/`) or full HTTP/HTTPS URLs. Mixed lists are not supported.
+- When using repository download (`gateway_archive_download_url`-style for Platform), set `repository_username`/`repository_password` or `repository_api_key`.
+
+## Gotchas
+
+- The `platform_server_dir` and `platform_services_dir` are derived from `platform_root_dir` and cannot be independently overridden via inventory — only `platform_root_dir` can be changed.
+- `platform_start_service: false` prevents service startup but the handler still fires if notified — the `when: platform_start_service | bool` condition is on the handler itself.
+- The sudoers entry for `chroot` is appended to `/etc/sudoers` with `lineinfile`. If the file has a `Defaults requiretty` directive, the entry will still be added but may not work correctly.
+- `platform_mongo_tls_ca_file` resolves to `platform_mongodb_ca_dest` when `platform_mongo_tls_enabled: true` and to `""` when disabled. The template uses this variable directly, so changing `platform_mongo_tls_enabled` without setting this var correctly will cause a broken properties file.
+- When `platform_redis_sentinels` is set, `platform_redis_host` is ignored by the Platform Redis client. Set `platform_redis_name` to match the sentinel master name used in the Redis role (`redis_sentinel_master_name`, default: `itentialmaster`).

--- a/roles/python/CLAUDE.md
+++ b/roles/python/CLAUDE.md
@@ -1,0 +1,48 @@
+# Role: python
+
+## Purpose
+
+Shared utility role for installing Python RPM packages and pip dependencies. Not called directly by playbooks — it is included by `gateway`, `mongodb`, and `platform` roles via `include_tasks` or `import_role`. Has no defaults of its own; all variables must be passed by the caller.
+
+## Entry Point Tasks — main.yml
+
+1. Install Python RPM packages via `dnf` using `python_packages` list (skipped when `offline_install_enabled` is true — callers handle offline Python install themselves)
+
+### install-dependencies.yml
+
+Called separately from `main.yml` by caller roles. Installs pip packages into either a virtualenv or via a pip executable.
+
+1. Assert that `python_pip_executable` or `python_venv` is defined
+2. If `python_venv` is defined: install `python_base_dependencies` then `python_app_dependencies` into the venv using `ansible.builtin.pip`
+3. If `python_pip_executable` is defined (and no venv): install `python_base_dependencies` then `python_app_dependencies` using that pip executable with `umask 0022`
+
+### create-symlinks.yml
+
+Creates symlinks for python and pip executables. Called by callers that need to set up `/usr/bin/python<N>` symlinks.
+
+## Variables (all must be provided by the caller)
+
+| Variable | Purpose |
+|----------|---------|
+| `python_packages` | List of RPM package names to install (e.g., `python39`, `python39-pip`) |
+| `python_base_dependencies` | List of base pip packages (e.g., `pip`, `setuptools`, `wheel`) |
+| `python_app_dependencies` | List of application-specific pip packages |
+| `python_pip_executable` | Absolute path to pip executable (e.g., `/usr/bin/pip3.11`) |
+| `python_venv` | Absolute path to a Python virtualenv (mutually exclusive with `python_pip_executable`) |
+| `offline_install_enabled` | Inherited from `common` defaults; controls whether `main.yml` installs packages |
+
+## How Callers Use This Role
+
+Each component role maps its own vars to the generic python vars when calling:
+
+| Caller Role | `python_packages` source | `python_pip_executable` source | venv? |
+|-------------|-------------------------|-------------------------------|-------|
+| `gateway` | `gateway_python_packages` | `gateway_pip_executable` | Yes (`gateway_python_venv`) |
+| `mongodb` | `mongodb_python_packages` | `mongodb_pip_executable` | Yes (`mongodb_python_venv`) |
+| `platform` | `platform_python_packages` | `platform_pip_executable` | No (system pip) |
+
+## Gotchas
+
+- `main.yml` only installs RPM packages; it does not call `install-dependencies.yml`. Callers must explicitly call `install-dependencies.yml` as a separate step.
+- `install-dependencies.yml` requires either `python_pip_executable` or `python_venv` — if neither is passed it fails immediately with an assert.
+- The role has no `defaults/` directory. Calling it without the required variables set will produce unclear errors.

--- a/roles/redis/CLAUDE.md
+++ b/roles/redis/CLAUDE.md
@@ -1,0 +1,181 @@
+# Role: redis
+
+## Purpose
+
+Installs and configures Redis and Redis Sentinel for use with Itential Platform. Supports installation from source (default) or from a YUM repository (Remi or system). Handles authentication (ACL users), TLS, replication, Sentinel setup, SELinux, logrotate, and firewalld.
+
+## Entry Point Tasks — main.yml
+
+1. Validate variables (`validate-vars.yml`) and set node type facts:
+   - `redis_is_master_node`, `redis_is_replica_node`, `redis_is_sentinel_node`, `redis_is_data_node`
+   - `redis_has_replicas`, `redis_has_sentinels`
+2. Install Redis (triggers `Enable and Start Redis` and `Enable and Start Redis Sentinel` handlers):
+   a. `install-common.yml` — create OS user/group, directories, security packages
+   b. `install-from-source.yml` — when `redis_install_from_source: true`
+   c. `install-from-repo.yml` — when `redis_install_from_source: false`
+3. Configure SELinux (when enforcing and install-from-source; loads `itential_redis_sentinel.te`)
+4. Configure TLS (`configure-redis-tls.yml`) — when `redis_tls_enabled: true`
+5. Configure Redis (`configure-redis.yml`) — when `redis_is_data_node`
+6. Configure Sentinel (`configure-sentinel.yml`) — when `redis_is_sentinel_node`
+7. Flush handlers, start and assert Redis is active (data nodes)
+8. Flush handlers, start and assert Redis Sentinel is active (sentinel nodes)
+
+## install-from-source.yml
+
+1. Check if `redis-server` binary exists and get its version
+2. If already installed and version matches `redis_source_url` archive name: skip
+3. Otherwise: create temp dir → install build packages (`tar`, `gcc`, `make`, etc.) → download source archive → unarchive → `make install USE_SYSTEMD=true PREFIX=/usr/local` → clean up → remove build packages
+
+## Key Variables
+
+### redis.yml defaults
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `redis_bin_dir` | `/usr/local/bin` (source) or `/usr/bin` (repo) | Binary location |
+| `redis_conf_dir` | `/etc/redis` | Config directory |
+| `redis_conf_file` | `/etc/redis/redis.conf` | Redis config file |
+| `redis_log_dir` | `/var/log/redis` | Log directory |
+| `redis_data_dir` | `/var/lib/redis` | Data directory |
+| `redis_db_filename` | `dump.rdb` | RDB filename |
+| `redis_owner` | `redis` | OS user |
+| `redis_group` | `redis` | OS group |
+| `redis_port` | `6379` | Listen port |
+| `redis_bind` | `127.0.0.1 {{ ansible_default_ipv4.address }}` | Bind addresses |
+| `redis_auth_enabled` | `true` | Enable ACL user authentication |
+| `redis_tls_enabled` | `false` | Enable TLS (disabled by default) |
+| `redis_replicaof` | `{{ groups['redis_master'][0] }} {{ redis_port }}` | Replication target (used on replica nodes) |
+| `redis_replica_priority` | `auto` | Sentinel failover priority; `auto` calculates from position |
+| `redis_user_admin_password` | `admin` | Admin user password |
+| `redis_user_itential_password` | `itential` | App user password |
+| `redis_user_repluser_password` | `repluser` | Replication user password |
+| `redis_user_sentineladmin_password` | `admin` | Sentinel admin password |
+| `redis_user_sentineluser_password` | `sentineluser` | Sentinel monitor user password |
+| `redis_user_monitor_password` | `monitor` | Monitor user password |
+| `redis_monitor_user_enabled` | `false` | Create the monitor user |
+| `redis_maxmemory_bytes` | `auto` | `auto` = 80% of RAM; or explicit bytes |
+| `redis_maxmemory_ratio` | `0.80` | Fraction of RAM to use when `redis_maxmemory_bytes: auto` |
+| `redis_maxmemory_min_mb` | `512` | Minimum maxmemory floor (MB) |
+| `redis_tls_port` | `6379` (default; see pki.yml for TLS port) | TLS port |
+| `redis_tls_auth_clients` | `no` | Whether to require client certificates |
+| `redis_tls_protocols` | `TLSv1.2 TLSv1.3` | Allowed TLS protocol versions |
+| `redis_certify_report_dir_remote` | `/var/tmp/itential-reports/redis` | Cert report dir on target |
+| `redis_certify_report_dir_local` | `/tmp/itential-reports/redis` | Cert report dir on control node |
+
+### sentinel.yml defaults
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `redis_sentinel_conf_file` | `/etc/redis/sentinel.conf` | Sentinel config file |
+| `redis_sentinel_log` | `/var/log/redis/sentinel.log` | Sentinel log path |
+| `redis_sentinel_master_name` | `itentialmaster` | Sentinel master set name |
+| `redis_sentinel_port` | `26379` | Sentinel listen port |
+| `redis_sentinel_bind` | `127.0.0.1 {{ ansible_default_ipv4.address }}` | Sentinel bind addresses |
+| `redis_sentinel_quorum` | `auto` | Auto-calculates as `(sentinel_count // 2) + 1`; or explicit integer |
+| `redis_sentinel_certify_report_dir_remote` | `/var/tmp/itential-reports/sentinel` | Sentinel cert report dir on target |
+| `redis_sentinel_certify_report_dir_local` | `/tmp/itential-reports/sentinel` | Sentinel cert report dir on control node |
+
+### install.yml defaults
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `redis_install_from_source` | `true` | Install from source (compiled); `false` = install from YUM |
+| `redis_build_packages` | `tar`, `unzip`, `gcc`, `gcc-c++`, `make`, `systemd-devel` | Packages needed to compile Redis |
+| `redis_security_packages` | `policycoreutils-python-utils` | SELinux management package |
+| `redis_remi_repo_url` | Remi enterprise URL | Used when installing from Remi repo |
+| `redis_epel_repo_url` | Fedora EPEL URL | Used when installing EPEL for Remi |
+
+### pki.yml defaults (TLS paths)
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `redis_pki_base_dir` | `/etc/pki/redis` | Base PKI directory |
+| `redis_pki_private_dir` | `{{ redis_pki_base_dir }}/private` | Private key subdirectory |
+| `redis_tls_cert_file` | `{{ inventory_hostname }}.crt` | Server cert filename |
+| `redis_tls_key_file` | `{{ inventory_hostname }}.key` | Server key filename |
+| `redis_tls_ca_file` | `ca-bundle.crt` | CA bundle filename |
+| `redis_tls_dh_params_file` | `dhparams.pem` | DH params filename |
+| `redis_sentinel_tls_cert_file` | `sentinel.crt` | Sentinel cert filename |
+| `redis_sentinel_tls_key_file` | `sentinel.key` | Sentinel key filename |
+| `redis_pki_src_dir` | `""` | Source directory on control node (required when TLS enabled) |
+| `redis_pki_owner` | `redis` | File/dir owner |
+| `redis_pki_group` | `redis` | File/dir group |
+| All `_dest` vars | Built from base dir + filename | Destination paths on target |
+| All `_src` vars | Built from `redis_pki_src_dir` + filename | Source paths on control node |
+
+## TLS Configuration
+
+TLS is **disabled by default** (`redis_tls_enabled: false`).
+
+Flow (`configure-redis-tls.yml`, runs when `redis_tls_enabled: true`):
+1. Create `redis_pki_base_dir` (mode `0750`)
+2. Create `redis_pki_private_dir` (mode `0700`)
+3. Copy server cert, server key, CA bundle, DH params from control node (each conditional on source path being non-empty)
+4. Each copy notifies `restart redis`
+
+The `redis.conf.j2` template includes TLS configuration blocks when `redis_tls_enabled: true`. Sentinel TLS certs (`sentinel.crt`, `sentinel.key`) are expected in `redis_pki_src_dir` when using TLS with Sentinel.
+
+To enable TLS, set in inventory:
+```yaml
+redis_tls_enabled: true
+redis_pki_src_dir: /path/to/certs/on/control/node
+```
+
+## Templates
+
+| Template | Rendered To | Purpose |
+|----------|-------------|---------|
+| `redis.conf.j2` | `/etc/redis/redis.conf` | Redis server configuration (auth, TLS, replication, ports, memory) |
+| `sentinel.conf.j2` | `/etc/redis/sentinel.conf` | Sentinel configuration (master monitoring, quorum, TLS) |
+| `redis.service.j2` | `/etc/systemd/system/redis.service` | Redis systemd unit |
+| `redis-sentinel.service.j2` | `/etc/systemd/system/redis-sentinel.service` | Redis Sentinel systemd unit |
+| `redis.logrotate.j2` | `/etc/logrotate.d/redis` | Redis log rotation |
+| `redis-sentinel.logrotate.j2` | `/etc/logrotate.d/redis-sentinel` | Sentinel log rotation |
+| `redis.preflight.j2` | Used by `preflight.yml` | Pre-install output |
+| `redis-validation-report.md.j2` | `redis_certify_report_dir_remote/<host>.md` | Certification report |
+
+## Handlers
+
+| Handler | Listen String | Action |
+|---------|--------------|--------|
+| Enable and Start Redis | `restart redis` | `systemctl restart redis` (throttle: 1; data nodes only) |
+| Enable and Start Redis Sentinel | (no listen string) | `systemctl restart redis-sentinel` (throttle: 1; sentinel nodes only) |
+| Update Itential release file | (separate notify) | Includes `update-release-file.yml` |
+
+Handler throttle (`throttle: 1`) ensures rolling restart of replicas — only one Redis node restarts at a time.
+
+## Inventory Groups
+
+| Group | Role |
+|-------|------|
+| `redis_master` | Primary data node |
+| `redis_replica` | Secondary data nodes |
+| `redis_sentinel` | Sentinel nodes (typically colocated with data nodes) |
+
+The same host can be in both `redis_master` and `redis_sentinel`. The role detects which groups a host belongs to and runs the appropriate configuration tasks.
+
+## Release-Specific Vars (vars/platform-release-6.yml)
+
+| Variable | Value |
+|----------|-------|
+| `redis_source_url` | `https://github.com/redis/redis/archive/7.4.6.tar.gz` (all OS versions) |
+| `redis_packages` (from repo) | `@redis:remi-7.2` (all OS versions) |
+
+Hardware specs for `verify` playbook (`redis_hw_specs`):
+- dev: 8 CPU, 16 GB RAM, 100 GB disk
+- test/prod: 8 CPU, 32 GB RAM, 100 GB disk
+
+## Dependencies / Assumptions
+
+- The `common` role must be applied first.
+- The `os` role should be applied before `redis` to ensure SELinux tools and build tools are available.
+- `redis_master` group must always have at least one member — `redis_replicaof` and sentinel config reference `groups['redis_master'][0]`.
+- When `redis_install_from_source: true`, build packages (`gcc`, `make`, `systemd-devel`, etc.) are installed, used for compilation, then removed. Offline mode requires these pre-staged in `redis_offline_control_node_rpms_dir/build/`.
+
+## Gotchas
+
+- `redis_install_from_source: true` is the default. The Remi repo install (`redis_install_from_source: false`) requires `common_install_yum_repos: true` and the string `remi` in `redis_packages`.
+- The source install checks the installed Redis version against the archive filename. Version mismatch triggers a full recompile. The comparison uses the tarball name (e.g., `redis-7.4.6`) not semantic version parsing.
+- `redis_sentinel_quorum: auto` computes quorum at template render time based on `groups['redis_sentinel'] | length`. For a 3-sentinel cluster this is 2 (majority). If you set an explicit value, ensure it is `<= number of sentinels`.
+- `redis_replica_priority: auto` calculates priority based on the host's index in the replica group. Explicit values `0-100` work; `0` means never promote.
+- The `throttle: 1` on the restart handler means in a 3-node cluster, each restart is serialized. This is intentional to prevent split-brain during rolling restarts.

--- a/roles/selinux/CLAUDE.md
+++ b/roles/selinux/CLAUDE.md
@@ -1,0 +1,50 @@
+# Role: selinux
+
+## Purpose
+
+Shared utility role for compiling and installing custom SELinux policy modules (`.te` files). Called by `mongodb`, `redis`, and `gateway` roles via `include_tasks`. Reads `.te` files from the **calling role's** `files/` directory (not this role's own files).
+
+## Entry Point Tasks — main.yml
+
+Entire block is guarded by `ansible_selinux.status == "enabled"`.
+
+1. Find all `*.te` files in `{{ ansible_parent_role_paths | first }}/files/` on the control node (delegated to localhost)
+2. Build list of policy files
+3. Check which policies are already installed via `semodule -l | grep <name>` (per file)
+4. Remove already-installed policies from the list to avoid recompilation
+5. For remaining policies:
+   a. Create a temp directory on the target node
+   b. Copy `.te` files from control node to target temp dir
+   c. Compile each: `checkmodule -M -m -o <name>.mod <name>.te`
+   d. Package each: `semodule_package -o <name>.pp -m <name>.mod`
+   e. Install all: `semodule -i *.pp` (from the temp dir)
+   f. Remove temp directory
+
+## configure-context.yml
+
+A second task file in this role. Called by individual component roles (e.g., mongodb, redis) to apply `semanage fcontext` and `restorecon` context labels. The calling role must pass the context rules — this file does not define any rules itself.
+
+## Variables
+
+None defined in this role. It reads `ansible_parent_role_paths` (an Ansible magic variable) to locate the calling role's `files/` directory.
+
+## SELinux Policy Files per Component Role
+
+| Role | Policy Files (in role's `files/`) |
+|------|----------------------------------|
+| `mongodb` | `itential_mongodb_cgroup_memory.te`, `itential_mongodb_proc_net.te`, `itential_mongodb_sysctl_fs.te`, `itential_mongodb_sysctl_net.te`, `itential_mongodb_var_lib_nfs.te` |
+| `redis` | `itential_redis_sentinel.te` |
+| `gateway` | (none — gateway calls `configure-selinux.yml` which includes its own inline tasks) |
+
+## Dependencies / Assumptions
+
+- Must be called with `include_tasks` or `import_role` from within a role that has `.te` files in its `files/` directory.
+- `ansible_parent_role_paths` is automatically set by Ansible when a role includes another role's tasks. If called incorrectly, the file discovery will fail silently (empty list) or error.
+- Requires `checkmodule`, `semodule_package`, and `semodule` to be installed on the target (provided by `policycoreutils` and `checkpolicy` packages from the `os` role).
+- The entire role is a no-op when SELinux is disabled or permissive (`ansible_selinux.status != "enabled"`).
+
+## Gotchas
+
+- The idempotency check uses `semodule -l | grep <filename_without_extension>`. If a policy is installed under a different name than the `.te` filename, this check will miss it and attempt to reinstall.
+- `semodule -i *.pp` runs from the temp directory using a shell glob — all compiled `.pp` files are installed in one command. Order of installation is not controlled.
+- The role uses `changed_when: result.rc == 0` on compile/package steps, which means every run where the policy is not already installed will show as changed, even on re-runs.


### PR DESCRIPTION
## Summary
- Adds a root-level `CLAUDE.md` covering collection metadata, all playbooks, inventory topologies, roles summary, global variables, TLS overview, offline install, and docs index
- Adds per-role `CLAUDE.md` for all 9 roles (`common`, `gateway`, `mongodb`, `offline`, `os`, `platform`, `python`, `redis`, `selinux`) covering task flow, key variables, TLS config, templates, handlers, and gotchas

## Test plan
- [ ] Review root `CLAUDE.md` for accuracy against playbooks and inventory examples
- [ ] Spot-check role `CLAUDE.md` variable tables against `roles/<role>/defaults/`
- [ ] Confirm no sensitive values (passwords, keys) were captured in docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)