### PR TITLE
Feature/v4

### DIFF
--- a/example_inventories/minimal/minimal_tls.yaml
+++ b/example_inventories/minimal/minimal_tls.yaml
@@ -64,10 +64,9 @@ all:
         platform_packages:
           - itential-platform-<version>.noarch.rpm
 
-        platform_webserver_https_enabled: true
-
         platform_https_pki_src_dir: </path/to/certs/on/control/node>
         platform_mongodb_pki_src_dir: "{{ platform_https_pki_src_dir }}"
+
 
 
 

--- a/example_inventories/minimal/minimal_tls.yaml
+++ b/example_inventories/minimal/minimal_tls.yaml
@@ -67,6 +67,7 @@ all:
         platform_https_pki_src_dir: </path/to/certs/on/control/node>
         platform_mongodb_pki_src_dir: "{{ platform_https_pki_src_dir }}"
 
+
         # The default MongoDB username, database name and TLS setting are used.
         # platform_mongo_user: itential
         # platform_mongo_db_name: itential

--- a/example_inventories/minimal/minimal_tls.yaml
+++ b/example_inventories/minimal/minimal_tls.yaml
@@ -64,8 +64,11 @@ all:
         platform_packages:
           - itential-platform-<version>.noarch.rpm
 
+        platform_webserver_https_enabled: true
+
         platform_https_pki_src_dir: </path/to/certs/on/control/node>
         platform_mongodb_pki_src_dir: "{{ platform_https_pki_src_dir }}"
+
 
 
 

--- a/example_inventories/minimal/minimal_tls.yaml
+++ b/example_inventories/minimal/minimal_tls.yaml
@@ -68,6 +68,7 @@ all:
         platform_mongodb_pki_src_dir: "{{ platform_https_pki_src_dir }}"
 
 
+
         # The default MongoDB username, database name and TLS setting are used.
         # platform_mongo_user: itential
         # platform_mongo_db_name: itential

--- a/example_inventories/minimal/minimal_tls.yaml
+++ b/example_inventories/minimal/minimal_tls.yaml
@@ -67,10 +67,6 @@ all:
         platform_https_pki_src_dir: </path/to/certs/on/control/node>
         platform_mongodb_pki_src_dir: "{{ platform_https_pki_src_dir }}"
 
-
-
-
-
         # The default MongoDB username, database name and TLS setting are used.
         # platform_mongo_user: itential
         # platform_mongo_db_name: itential

--- a/playbooks/nginx_configure.yml
+++ b/playbooks/nginx_configure.yml
@@ -37,6 +37,8 @@
         state: enabled
         zone: public
         immediate: true
+      vars:
+        ansible_python_interpreter: "{{ '/usr/libexec/platform-python' if (ansible_os_family == 'RedHat' and ansible_distribution_major_version == '8') else 'auto' }}"
       when:
         - ansible_facts.services["firewalld.service"] is defined
         - ansible_facts.services["firewalld.service"].state == "running"

--- a/roles/gateway/tasks/main.yml
+++ b/roles/gateway/tasks/main.yml
@@ -314,6 +314,8 @@
         state: enabled
         zone: public
         immediate: true
+      vars:
+        ansible_python_interpreter: "{{ '/usr/libexec/platform-python' if (ansible_os_family == 'RedHat' and ansible_distribution_major_version == '8') else 'auto' }}"
       when:
         - not (gateway_https_enabled | bool)
         - ansible_facts.services["firewalld.service"] is defined
@@ -327,6 +329,8 @@
         state: enabled
         zone: public
         immediate: true
+      vars:
+        ansible_python_interpreter: "{{ '/usr/libexec/platform-python' if (ansible_os_family == 'RedHat' and ansible_distribution_major_version == '8') else 'auto' }}"
       when:
         - gateway_https_enabled | bool
         - ansible_facts.services["firewalld.service"] is defined

--- a/roles/mongodb/tasks/install-mongodb.yml
+++ b/roles/mongodb/tasks/install-mongodb.yml
@@ -84,6 +84,8 @@
     state: enabled
     zone: public
     immediate: true
+  vars:
+    ansible_python_interpreter: "{{ '/usr/libexec/platform-python' if (ansible_os_family == 'RedHat' and ansible_distribution_major_version == '8') else 'auto' }}"
   when:
     - ansible_facts.services["firewalld.service"] is defined
     - ansible_facts.services["firewalld.service"].state == "running"

--- a/roles/platform/tasks/configure-firewalld.yml
+++ b/roles/platform/tasks/configure-firewalld.yml
@@ -12,6 +12,8 @@
     state: enabled
     zone: public
     immediate: true
+  vars:
+    ansible_python_interpreter: "{{ '/usr/libexec/platform-python' if (ansible_os_family == 'RedHat' and ansible_distribution_major_version == '8') else 'auto' }}"
   when:
     - ansible_facts.services["firewalld.service"] is defined
     - ansible_facts.services["firewalld.service"].state == "running"
@@ -25,6 +27,8 @@
     state: enabled
     zone: public
     immediate: true
+  vars:
+    ansible_python_interpreter: "{{ '/usr/libexec/platform-python' if (ansible_os_family == 'RedHat' and ansible_distribution_major_version == '8') else 'auto' }}"
   when:
     - ansible_facts.services["firewalld.service"] is defined
     - ansible_facts.services["firewalld.service"].state == "running"
@@ -38,6 +42,8 @@
     state: enabled
     zone: public
     immediate: true
+  vars:
+    ansible_python_interpreter: "{{ '/usr/libexec/platform-python' if (ansible_os_family == 'RedHat' and ansible_distribution_major_version == '8') else 'auto' }}"
   when:
     - ansible_facts.services["firewalld.service"] is defined
     - ansible_facts.services["firewalld.service"].state == "running"

--- a/roles/redis/tasks/configure-redis.yml
+++ b/roles/redis/tasks/configure-redis.yml
@@ -11,6 +11,8 @@
     state: enabled
     zone: public
     immediate: true
+  vars:
+    ansible_python_interpreter: "{{ '/usr/libexec/platform-python' if (ansible_os_family == 'RedHat' and ansible_distribution_major_version == '8') else 'auto' }}"
   when:
     - ansible_facts.services["firewalld.service"] is defined
     - ansible_facts.services["firewalld.service"].state == "running"

--- a/roles/redis/tasks/configure-sentinel.yml
+++ b/roles/redis/tasks/configure-sentinel.yml
@@ -11,6 +11,8 @@
     state: enabled
     zone: public
     immediate: true
+  vars:
+    ansible_python_interpreter: "{{ '/usr/libexec/platform-python' if (ansible_os_family == 'RedHat' and ansible_distribution_major_version == '8') else 'auto' }}"
   when:
     - ansible_facts.services["firewalld.service"] is defined
     - ansible_facts.services["firewalld.service"].state == "running"


### PR DESCRIPTION
On RHEL and Rocky 8, python3-firewall installs exclusively into the Python 3.6
site-packages at /usr/lib/python3.6/site-packages/. When ansible_python_interpreter
is set to a newer Python (3.9, 3.11, etc.) in the customer inventory, the
ansible.posix.firewalld module fails to import the firewall library.

Add a task-level vars override on all firewalld tasks to force
/usr/libexec/platform-python on RHEL/Rocky 8, which is the only interpreter
that has the python3-firewall bindings. On all other distros the interpreter
falls back to auto-discovery.