### PR TITLE
Add OS family validation to prevent  failures on unsupported distros

### DIFF
--- a/roles/mongodb/tasks/validate-vars.yml
+++ b/roles/mongodb/tasks/validate-vars.yml
@@ -44,6 +44,13 @@
               Deployer does not support installing MongoDB
               for Itential Platform release {{ platform_release }}
 
+        - name: Check for valid OS for MongoDB installation
+          ansible.builtin.assert:
+            that: ansible_os_family == 'RedHat'
+            fail_msg: >-
+              Deployer does not support installing MongoDB on {{ ansible_distribution }}.
+              Supported platforms: Red Hat family (RHEL 8/9, Rocky Linux 8/9, AlmaLinux 8/9, Amazon Linux 2023).
+
         - name: Set mongodb_version to the default value when not defined in inventory
           ansible.builtin.set_fact:
             mongodb_version: "{{ mongodb_version_default[ansible_distribution_major_version] }}"

--- a/roles/platform/tasks/validate-vars.yml
+++ b/roles/platform/tasks/validate-vars.yml
@@ -160,6 +160,13 @@
             fail_msg: >-
               Deployer does not support installing Itential Platform release {{ platform_release }}"
 
+        - name: Check for valid OS for Itential Platform installation
+          ansible.builtin.assert:
+            that: ansible_os_family == 'RedHat'
+            fail_msg: >-
+              Deployer does not support installing Itential Platform on {{ ansible_distribution }}.
+              Supported platforms: Red Hat family (RHEL 8/9, Rocky Linux 8/9, AlmaLinux 8/9, Amazon Linux 2023).
+
         - name: Set platform_nodejs_package to the default value
                 when not defined in inventory
           ansible.builtin.set_fact:

--- a/roles/redis/tasks/validate-vars.yml
+++ b/roles/redis/tasks/validate-vars.yml
@@ -87,6 +87,13 @@
               Deployer does not support installing Redis
               for Itential Platform release {{ platform_release }}
 
+        - name: Check for valid OS for Redis installation
+          ansible.builtin.assert:
+            that: ansible_os_family == 'RedHat'
+            fail_msg: >-
+              Deployer does not support installing Redis on {{ ansible_distribution }}.
+              Supported platforms: Red Hat family (RHEL 8/9, Rocky Linux 8/9, AlmaLinux 8/9, Amazon Linux 2023).
+
         - name: Set redis_source_url to the default value when not defined in inventory
           ansible.builtin.set_fact:
             redis_source_url: "{{ redis_source_url_default[ansible_distribution_major_version] }}"


### PR DESCRIPTION
On unsupported OS families (e.g. SUSE), the deployer failed with a
Jinja2 key error when looking up OS-keyed defaults like
redis_source_url_default[ansible_distribution_major_version]. The
existing release check only validates the platform_release value, not
the OS. Added an explicit ansible_os_family == 'RedHat' assert in the
redis, mongodb, and platform roles immediately after the release check
so unsupported OS installs fail with a clear error message.