### PR TITLE
redis: grant monitor user ACL perms needed for BullMQ queue metrics

### DIFF
--- a/roles/redis/templates/redis.conf.j2
+++ b/roles/redis/templates/redis.conf.j2
@@ -923,7 +923,7 @@ user default off
 user admin on allkeys allchannels allcommands >{{ redis_user_admin_password }}
 user itential on ~* &* -@all +@read +@write +@stream +@transaction +@sortedset +@list +@hash +@string +@fast +@scripting +@connection +@pubsub +script|load +script|exists -script|flush -flushall -flushdb -save -bgsave -bgrewriteaof -replicaof -psync -replconf -shutdown -failover -cluster -asking -sync -readonly -readwrite +info +role >{{ redis_user_itential_password }}
 {% if redis_monitor_user_enabled and redis_user_monitor_password %}
-user monitor on -@all +@connection +memory -readonly +strlen +config|get +xinfo +pfcount -quit +zcard +type +xlen -readwrite -command +client -wait +scard +llen +hlen +get +eval +slowlog +cluster|info +cluster|slots +cluster|nodes -hello -echo +info +latency +scan -reset -auth -asking >{{ redis_user_monitor_password }}
+user monitor on sanitize-payload ~* resetchannels -@all +@connection +memory -readonly +strlen +config|get +xinfo +pfcount -quit +zcard +type +xlen -readwrite -command +client -wait +scard +llen +hlen +get +eval +slowlog +cluster|info +cluster|slots +cluster|nodes -hello -echo +info +latency +scan -reset -auth -asking +evalsha +memory|usage +xinfo|stream >{{ redis_user_monitor_password }}
 {% endif %}
 {% if redis_is_data_node %}
 {% if redis_has_replicas %}


### PR DESCRIPTION
Extends the monitor user ACL in redis.conf.j2 so redis_exporter can collect BullMQ queue metrics without NOPERM errors.
redis_exporter's Lua collection script needs +eval/+evalsha plus per-key +memory|usage, +xinfo|stream, and TYPE access across the queue keyspace. Adds ~*, +eval, +evalsha, +memory|usage, +xinfo|stream; sets sanitize-payload and resetchannels to match the rule set already validated and running in prod.
Net effect: the monitor user gains read access to queue internals (stream entries, key memory footprint) and script execution. See note below on scope.