### PR TITLE
Add mongo read/write concern capture to platform certify

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@
 |-------|-------|
 | Namespace | `itential` |
 | Name | `deployer` |
-| Version | `3.7.2` |
+| Version | `4.0.0` |
 | Min ansible-core | `>=2.11, <2.17` |
 | Min Python | `>=3.9` |
 

--- a/docs/certify_guide.md
+++ b/docs/certify_guide.md
@@ -164,7 +164,14 @@ Confirms the properties file and systemd unit file are present and shows file pe
 
 ### Critical Configuration Properties
 
-Key values read directly from `platform.properties`: MongoDB URL and TLS settings, Redis host and Sentinel configuration, webserver ports, log file paths, and the default admin username.
+Key values read directly from `platform.properties`: MongoDB URL and TLS settings, MongoDB read/write concern levels, Redis host and Sentinel configuration, webserver ports, log file paths, and the default admin username.
+
+| Property | Description |
+|----------|-------------|
+| `mongo_read_concern` | The read concern level configured for the IAP MongoDB connection. Recommended value: `majority`. If not set, Platform uses the MongoDB driver default (`local`), which allows reads of data that may be rolled back on failover. |
+| `mongo_write_concern` | The write concern level configured for the IAP MongoDB connection. Recommended value: `majority`. If not set, Platform uses the MongoDB driver default, which may acknowledge writes before they are replicated to a majority of nodes. |
+
+Both values are captured as-is from the properties file. The report shows `Not set` when either property is absent. No validation or enforcement is performed — this is an observation check to surface the current configuration for review.
 
 ### Custom Services
 

--- a/roles/platform/tasks/certify-platform.yml
+++ b/roles/platform/tasks/certify-platform.yml
@@ -140,6 +140,28 @@
   changed_when: false
   when: platform_conf_file.stat.exists
 
+- name: Parse Itential config for mongo_read_concern
+  ansible.builtin.shell:
+    cmd: >
+      grep '^mongo_read_concern' /etc/itential/platform.properties |
+      awk -F'=' '{print $2}' |
+      xargs
+  register: platform_mongo_read_concern
+  ignore_errors: true
+  changed_when: false
+  when: platform_conf_file.stat.exists
+
+- name: Parse Itential config for mongo_write_concern
+  ansible.builtin.shell:
+    cmd: >
+      grep '^mongo_write_concern' /etc/itential/platform.properties |
+      awk -F'=' '{print $2}' |
+      xargs
+  register: platform_mongo_write_concern
+  ignore_errors: true
+  changed_when: false
+  when: platform_conf_file.stat.exists
+
 - name: Parse Itential config for redis_username
   ansible.builtin.shell:
     cmd: >

--- a/roles/platform/templates/platform-validation-report.md.j2
+++ b/roles/platform/templates/platform-validation-report.md.j2
@@ -102,6 +102,8 @@ Host details not available
 - **mongo_db_name:** {{ platform_mongo_db_name.stdout | default('Unknown') }}
 - **mongo_url:** {{ platform_mongo_url_masked | default('Unknown') }}
 - **mongo_tls_enabled:** {{ platform_mongo_tls_enabled.stdout | default('Unknown') }}
+- **mongo_read_concern:** {{ (platform_mongo_read_concern.stdout | default('')) or 'Not set' }}
+- **mongo_write_concern:** {{ (platform_mongo_write_concern.stdout | default('')) or 'Not set' }}
 - **redis_db:** {{ (platform_mongo_auth_db.stdout | default('')) or 'Default value' }}
 - **redis_user:** {{ (platform_mongo_auth_db.stdout | default('')) or 'Default value' }}
 - **redis_host:** {{ (platform_redis_host.stdout | default('')) or 'Unknown' }}


### PR DESCRIPTION
Adds two new tasks to certify-platform.yml to read mongo_read_concern and mongo_write_concern from platform.properties and surface them in the certification report. Both values are observation-only - no validation or enforcement. Recommended value for both is majority.

Also updates certify_guide.md to document the new properties and corrects the collection version in CLAUDE.md to 4.0.0.