### PR TITLE
Add tasks to verify HTTPS cert variables

### DIFF
--- a/roles/common/tasks/verify-host.yml
+++ b/roles/common/tasks/verify-host.yml
@@ -164,20 +164,3 @@
     quiet: true
   ignore_errors: true
   register: proxy_validation
-
-# Display results
-- name: Display failed validation results
-  ansible.builtin.debug:
-    msg: "{{ validation_errors }}"
-  when: cpu_validation is failed or memory_validation is failed or disk_validation is failed
-
-# Assert that none of the tests failed
-- name: Verify that all tests passed
-  ansible.builtin.assert:
-    that:
-      - "cpu_validation is not failed"
-      - "memory_validation is not failed"
-      - "disk_validation is not failed"
-      - "proxy_validation is not failed"
-    fail_msg: "See above, assertions not passed! ✗"
-    success_msg: "All assertions passed! ✓"

--- a/roles/common/tasks/verify-results.yml
+++ b/roles/common/tasks/verify-results.yml
@@ -1,0 +1,21 @@
+# Copyright (c) 2026, Itential, Inc
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+---
+
+# Display results
+- name: Display failed validation results
+  ansible.builtin.debug:
+    msg: "{{ validation_errors }}"
+  when: cpu_validation is failed or memory_validation is failed or disk_validation is failed or platform_validation is failed
+
+# Assert that none of the tests failed
+- name: Verify that all tests passed
+  ansible.builtin.assert:
+    that:
+      - "cpu_validation is not failed"
+      - "memory_validation is not failed"
+      - "disk_validation is not failed"
+      - "proxy_validation is not failed"
+      - "platform_validation is not failed"
+    fail_msg: "See above, assertions not passed! ✗"
+    success_msg: "All assertions passed! ✓"

--- a/roles/mongodb/tasks/verify-mongodb.yml
+++ b/roles/mongodb/tasks/verify-mongodb.yml
@@ -19,3 +19,8 @@
     hw_specs_var_name: "mongodb_hw_specs"
 
 # mongodb specific verification tasks go here...
+
+- name: Verify Platform host requirements
+  ansible.builtin.include_role:
+    name: common
+    tasks_from: verify-results

--- a/roles/platform/tasks/verify-platform.yml
+++ b/roles/platform/tasks/verify-platform.yml
@@ -18,4 +18,51 @@
     component_name: "Platform"
     hw_specs_var_name: "platform_hw_specs"
 
-    # platform specific verification tasks go here...
+# platform specific verification tasks go here...
+- name: Verify TLS certs for platform webserver are defined
+  ansible.builtin.assert:
+    that: platform_https_pki_src_dir is defined and platform_https_pki_src_dir | length > 0
+    fail_msg: "TLS certificate directory is undefined. Itential Platform requires TLS certificates."
+    success_msg: "TLS certificate directory is defined"
+    quiet: true
+  ignore_errors: true
+  register: platform_tls_dir_validation
+  when: platform_webserver_https_enabled | bool
+
+- name: Verify that expected certificate files exist on the control node
+  ansible.builtin.stat:
+    path: "{{ platform_https_pki_src_dir }}/{{ item }}"
+  loop:
+    - "{{ platform_https_cert_file }}"
+    - "{{ platform_https_key_file }}"
+    - "{{ platform_https_ca_file }}"
+  register: cert_file_stats
+  delegate_to: localhost
+  become: false
+  when:
+    - platform_webserver_https_enabled | bool
+    - platform_tls_dir_validation is not failed
+
+- name: Assert that all expected certificate files exist
+  ansible.builtin.assert:
+    that: cert_file_stats.results | map(attribute='stat.exists') | list | min
+    fail_msg: "One or more expected certificate files are missing in {{ platform_https_pki_src_dir }}"
+    success_msg: "All expected certificate files are present"
+    quiet: true
+  ignore_errors: true
+  register: platform_tls_contents_validation
+  when:
+    - platform_webserver_https_enabled | bool
+    - platform_tls_dir_validation is not failed
+
+- name: Add TLS files error to list
+  ansible.builtin.set_fact:
+    validation_errors: "{{ validation_errors + ['Platform TLS: TLS files for Itential Platform webserver appear to be missing'] }}"
+  when:
+    - platform_webserver_https_enabled | bool
+    - platform_tls_dir_validation is failed or platform_tls_contents_validation is failed
+
+- name: Verify Platform host requirements
+  ansible.builtin.include_role:
+    name: common
+    tasks_from: verify-results

--- a/roles/redis/tasks/verify-redis.yml
+++ b/roles/redis/tasks/verify-redis.yml
@@ -19,3 +19,8 @@
     hw_specs_var_name: "redis_hw_specs"
 
 # redis specific verification tasks go here...
+
+- name: Verify Platform host requirements
+  ansible.builtin.include_role:
+    name: common
+    tasks_from: verify-results

--- a/roles/redis/tasks/verify-sentinel.yml
+++ b/roles/redis/tasks/verify-sentinel.yml
@@ -19,3 +19,8 @@
     hw_specs_var_name: "redis_hw_specs"
 
 # redis sentinel specific verification tasks go here...
+
+- name: Verify Platform host requirements
+  ansible.builtin.include_role:
+    name: common
+    tasks_from: verify-results


### PR DESCRIPTION
Adds pre-install verification that the expected HTTPS TLS certificate files are present on the Ansible control node before the Platform role attempts to deploy them to target hosts. If the vars are undefined or the files not present it considers this as an ignored error and does not prevent the installation from happening despite the missing files.