### PR TITLE
Fix issue with setting mongodb node type facts

### DIFF
--- a/roles/mongodb/tasks/main.yml
+++ b/roles/mongodb/tasks/main.yml
@@ -1,11 +1,6 @@
 # Copyright (c) 2024, Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
-- name: Include tasks to validate variables
-  ansible.builtin.include_tasks:
-    file: validate-vars.yml
-  tags: always
-
 # Set node type facts based on inventory group membership.
 # mongodb_primary group hosts get the primary role with higher priority.
 # mongodb_replica group hosts get the secondary role with lower priority.
@@ -15,6 +10,11 @@
     mongodb_is_replica_node: "{{ 'mongodb_replica' in group_names }}"
     mongodb_data_nodes: "{{ groups['mongodb_primary'] | default([]) + groups['mongodb_replica'] | default([]) }}"
     mongodb_has_replicas: "{{ groups['mongodb_replica'] is defined and groups['mongodb_replica'] | length > 0 }}"
+
+- name: Include tasks to validate variables
+  ansible.builtin.include_tasks:
+    file: validate-vars.yml
+  tags: always
 
 # Installs all the necessary components and dependencies for MongoDB.
 # This will start the server with the simplest config.


### PR DESCRIPTION
The mongodb role was including validate-vars, which referenced the node type fact `mongodb_has_replicas` before it was set. The node type facts are now set before including validate-vars.