### PR TITLE
Add Itential Artifactory to required repository list

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,9 +222,11 @@ the Deployer will either install the required repository or download the package
 | Ansible Control Node | <https://galaxy.ansible.com> | TCP | Itential and community Ansible collections |
 | Ansible Control Node | <https://pypi.org> | TCP | Python modules |
 | Itential Gateway | <https://registry.aws.itential.com> | TCP | Itential packages |
+| Itential Gateway | <https://itential.jfrog.io> | TCP | Itential packages |
 | Itential Gateway | <https://galaxy.ansible.com> | TCP | Community Ansible collections |
 | Itential Gateway | <https://pypi.org> | TCP | Python modules |
 | Itential Platform | <https://registry.aws.itential.com> | TCP | Itential packages |
+| Itential Platform | <https://itential.jfrog.io> | TCP | Itential packages |
 | Itential Platform | <https://registry.npmjs.org> | TCP | Core NPM packages |
 | Itential Platform | <https://pypi.org> | TCP | Python modules |
 | Itential Platform | <https://gitlab.com> | TCP | Platform Opensource Adapters NodeJS source repository |

--- a/roles/gateway/vars/main.yml
+++ b/roles/gateway/vars/main.yml
@@ -21,6 +21,9 @@ gateway_required_repositories:
   - url: "https://registry.aws.itential.com"
     type: bare
     notes: "Itential packages"
+  - url: "https://itential.jfrog.io"
+    type: bare
+    notes: "Itential packages"
   - url: "https://galaxy.ansible.com"
     type: bare
     notes: "Community Ansible collections"

--- a/roles/platform/vars/main.yml
+++ b/roles/platform/vars/main.yml
@@ -26,6 +26,9 @@ platform_required_repositories:
   - url: "https://registry.aws.itential.com"
     type: bare
     notes: "Itential packages"
+  - url: "https://itential.jfrog.io"
+    type: bare
+    notes: "Itential packages"
   - url: "https://registry.npmjs.org"
     type: bare
     notes: "Core NPM packages"


### PR DESCRIPTION
- roles/gateway/vars/main.yml — added to gateway_required_repositories
- roles/platform/vars/main.yml — added to platform_required_repositories
- README.md — added rows to the "Required Public Repositories" table for both Gateway and Platform
- (Not added to Redis/MongoDB — those don't reference registry.aws.itential.com at all; they don't install Itential-hosted packages.)