### PR TITLE
Change platform webserver cache control enabled default to true

### DIFF
--- a/docs/itential_platform_guide.md
+++ b/docs/itential_platform_guide.md
@@ -212,7 +212,7 @@ located in `roles/platform/defaults/main/webserver.yml`.
 
 | Variable | Type | Description | Default Value |
 | :------- | :--- | :---------- | :------------ |
-| platform_webserver_cache_control_enabled | Boolean | A toggle to instruct the webserver to include HTTP cache control headers on the response. | `false` |
+| platform_webserver_cache_control_enabled | Boolean | A toggle to instruct the webserver to include HTTP cache control headers on the response. If left unset in `platform.properties`, Itential Platform itself defaults this to `false`; the deployer explicitly overrides that default to `true`. | `true` |
 | platform_webserver_timeout | Integer | Timeout to use for incoming HTTP requests to the platform API, in milliseconds. | 300000 |
 | platform_webserver_response_header_access_control_allow_origin | String | The value of the HTTP Access-Control-Allow-Origin header returned to clients. | `"*"` |
 | platform_webserver_http_enabled | Boolean | If true, allows the webserver to respond to insecure HTTP requests. | `true` |

--- a/roles/platform/CLAUDE.md
+++ b/roles/platform/CLAUDE.md
@@ -79,7 +79,7 @@ Installs and configures Itential Platform (IAP). Handles OS user/directory setup
 | `platform_webserver_https_port` | `3443` | HTTPS port |
 | `platform_webserver_https_ciphers` | Long cipher list | Allowed TLS ciphers |
 | `platform_webserver_https_secure_protocol` | `TLS_method` | OpenSSL method |
-| `platform_webserver_cache_control_enabled` | `false` | HTTP cache control headers |
+| `platform_webserver_cache_control_enabled` | `true` | HTTP cache control headers. Itential Platform's own application default (when left unset in `platform.properties`) is `false` — the deployer explicitly overrides it to `true`. |
 | `platform_webserver_timeout` | `300000` | Request timeout (ms) |
 
 ### mongodb.yml defaults

--- a/roles/platform/defaults/main/webserver.yml
+++ b/roles/platform/defaults/main/webserver.yml
@@ -1,8 +1,10 @@
 # Copyright (c) 2024, Itential, Inc
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
-# A toggle to instruct the webserver to include HTTP cache control headers on the response.
-platform_webserver_cache_control_enabled:
+# A toggle to instruct the webserver to include HTTP cache control headers on the response. If
+# left unset in platform.properties, Itential Platform itself defaults this to false; the
+# deployer explicitly overrides that default to true.
+platform_webserver_cache_control_enabled: true
 
 # Timeout to use for incoming HTTP requests to the platform API, in milliseconds.
 platform_webserver_timeout:


### PR DESCRIPTION
Changed the platform_webserver_cache_control_enabled default to 'true'. Previously it was unset.

Updated three places to reflect platform_webserver_cache_control_enabled now defaulting to true in the deployer, and to note that Itential Platform's own application default (when unset in platform.properties) is false:

- roles/platform/defaults/main/webserver.yml — expanded the comment above the var to state the override explicitly.
- roles/platform/CLAUDE.md — updated the webserver.yml defaults table row (default now true, purpose column notes the app's own default is false).
- docs/itential_platform_guide.md — updated the Webserver Variables table row the same way.